### PR TITLE
Ccp4cloud

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+**[0.2.1]**
+
+*Added*
+
+- Modifications for CCP4 cloud
+- Coloured Af2 pfam visualisation by pLDDT score
+- Added B-factor calculating to downloaded AF2 models
+
 **[0.2.0]**
 
 *Added*

--- a/bin/mrparse
+++ b/bin/mrparse
@@ -27,7 +27,8 @@ def main():
                               pdb_dir=args.pdb_dir,
                               db_lvl=args.db_lvl,
                               tmhmm_exe=args.tmhmm_exe,
-                              deepcoil_exe=args.deepcoil_exe)
+                              deepcoil_exe=args.deepcoil_exe,
+                              ccp4cloud=args.ccp4cloud)
     except KeyboardInterrupt:
         sys.stderr.write("Interrupted by keyboard!")
         return 0

--- a/data/mrparse.config
+++ b/data/mrparse.config
@@ -5,5 +5,5 @@ pdb_dir = pdb_files
 
 [Executables]
 tmhmm_exe = tmhmm
-deepcoil_exe = /Users/adamsimpkin/opt/DeepCoil-5385315/deepcoil.py
+deepcoil_exe = deepcoil
 

--- a/data/mrparse.config
+++ b/data/mrparse.config
@@ -1,23 +1,9 @@
-##########################################################
-# This config file is designed to allow you to set MrParse
-# settings easier and in a more convenient format.
-# It allows you to set directory/executable paths as well
-# as other settings specific to the MrParse pipeline.
-#
-# IMPORTANT:
-#       Although filenames can be set in this config file,
-#       please consider that you might encounter
-#       unexpected or unspotted errors in future runs.
-#
-# Author: hlasimpk
-# Date: 11.08.2021
-##########################################################
-
 [Defaults]
-db_lvl=95
-run_serial=False
-pdb_dir=pdb_files
+db_lvl = 95
+run_serial = False
+pdb_dir = pdb_files
 
 [Executables]
-tmhmm_exe=tmhmm
-deepcoil_exe=deepcoil
+tmhmm_exe = tmhmm
+deepcoil_exe = /Users/adamsimpkin/opt/DeepCoil-5385315/deepcoil.py
+

--- a/mrparse/html/mrparse.html.jinja2
+++ b/mrparse/html/mrparse.html.jinja2
@@ -51,9 +51,9 @@
 
 <body style="margin:1%;font-family:'Lato'">
   <div style="background-color:#efefef;color:#3b3b3dff;padding:20px">
-  <h1>MrParse Homolog Search</h1>
+  <h1>MrParse Analysis</h1>
   <h3>Version: 0.2.1</h3>
-  <p>MrParse: a program to find and analyse search models for Crystallographic Molecular Replacement.
+  <p>MrParse: a program to find and analyse search models for crystallographic Molecular Replacement.
   The program is being developed by <a href="https://www.liverpool.ac.uk/integrative-biology/staff/daniel-rigden/"
   target="_blank">Dan Rigden's group</a> at the University of Liverpool.</p>
   <p>MrParse is currently under development and we are keen to make it as useful to the community as possible. If you have any

--- a/mrparse/html/mrparse.html.jinja2
+++ b/mrparse/html/mrparse.html.jinja2
@@ -20,9 +20,6 @@
   <!-- in order to standardize the look of text, and in order to make it work at
        all in older browsers (and IE), we need the canvas text library. And, in turn,
        that library uses a font description in a separate javascript file -->
-  <!-->
-  <script type="text/javascript" src="pfam/static/javascripts/canvas.text.js?dontUseMoz=true&amp;reimplement=true"></script>
-  </!-->
   <script type="text/javascript" src="{{ mrparse_html_dir }}/pfam/static/javascripts/canvas.text.js?dontUseMoz=true&amp;reimplement=true"></script>
   <script type="text/javascript" src="{{ mrparse_html_dir }}/pfam/static/javascripts/faces/optimer-bold-normal.js"></script>
 

--- a/mrparse/html/mrparse.html.jinja2
+++ b/mrparse/html/mrparse.html.jinja2
@@ -55,8 +55,8 @@
 <body style="margin:1%;font-family:'Lato'">
   <div style="background-color:#efefef;color:#3b3b3dff;padding:20px">
   <h1>MrParse Homolog Search</h1>
-  <h3>Version: 0.1.8</h3>
-  <p>This is the alpha-release of MrParse: a program to find and analyse search models for Crystallographic Molecular Replacement.
+  <h3>Version: 0.2.1</h3>
+  <p>MrParse: a program to find and analyse search models for Crystallographic Molecular Replacement.
   The program is being developed by <a href="https://www.liverpool.ac.uk/integrative-biology/staff/daniel-rigden/"
   target="_blank">Dan Rigden's group</a> at the University of Liverpool.</p>
   <p>MrParse is currently under development and we are keen to make it as useful to the community as possible. If you have any

--- a/mrparse/html/mrparse_vue.js
+++ b/mrparse/html/mrparse_vue.js
@@ -221,7 +221,10 @@ Vue.component('homolog-table', {
       </thead>
       <tbody>
         <tr v-for="homolog in homologs">
-          <td><a v-bind:href="homolog.pdb_file">{{ homolog.name }}</a></td>
+          <td>
+          <a v-if="homolog.pdb_file" :href="homolog.pdb_file">{{ homolog.name }}</a>
+          <a v-else>{{ homolog.name }}</a>
+          </td>
           <td><a v-bind:href="homolog.pdb_url" target="_blank">{{ homolog.pdb_id }}</a></td>
           <td>{{ homolog.resolution  | decimalPlaces }}</td>
           <td>{{ homolog.region_id }}</td>
@@ -308,7 +311,10 @@ Vue.component('model-table', {
       </thead>
       <tbody>
         <tr v-for="model in models">
-          <td><a v-bind:href="model.pdb_file">{{ model.name }}</a></td>
+          <td>
+          <a v-if="model.pdb_file" :href="model.pdb_file">{{ model.name }}</a>
+          <a v-else>{{ model.name }}</a>
+          </td>
           <td><a v-bind:href="model.model_url" target="_blank">{{ model.model_id }}</a></td>
           <td>{{ model.date_made }}</td>
           <td>{{ model.region_id }}</td>

--- a/mrparse/html/mrparse_vue.js
+++ b/mrparse/html/mrparse_vue.js
@@ -135,7 +135,10 @@ Vue.component('hkl-info-table', {
 </thead>
 <tbody>
   <tr>
-    <td><a v-bind:href="hklinfo.hklin">{{ hklinfo.name }}</a></td>
+    <td>
+    <a v-if="hklinfo.hklin" :href="hklinfo.hklin">{{ hklinfo.name }}</a>
+    <a v-else>{{ hklinfo.name }}</a>
+    </td>
     <td>{{ hklinfo.resolution | decimalPlaces }}</td>
     <td>{{ hklinfo.space_group }}</td>
     <td>{{ hklinfo.has_ncs }}</td>

--- a/mrparse/mr_alphafold.py
+++ b/mrparse/mr_alphafold.py
@@ -5,7 +5,9 @@ Created on 23 Jul 2021
 """
 from collections import OrderedDict
 import gemmi
+from itertools import groupby
 import logging
+from operator import itemgetter
 import os
 import numpy as np
 import requests
@@ -224,11 +226,11 @@ def get_plddt_regions(struct, seqid_range):
     for i, plddt in residues:
         if plddt < 50:
             v_low.append(i)
-        elif 70 > plddt > 50:
+        elif 70 > plddt >= 50:
             low.append(i)
-        elif 90 > plddt > 70:
+        elif 90 > plddt >= 70:
             confident.append(i)
-        elif plddt > 90:
+        elif plddt >= 90:
             v_high.append(i)
 
     regions['v_low'] = _get_regions(v_low)
@@ -241,20 +243,10 @@ def get_plddt_regions(struct, seqid_range):
 
 def _get_regions(residues):
     regions = []
-    start = finish = None
-    for i in residues:
-        if start:
-            if i - 1 == finish:
-                finish = i
-            else:
-                regions.append([start, finish])
-                start = i
-                finish = i
-        else:
-            start = i
-            finish = i
-    if start:
-        regions.append([start, finish])
+    for k, g in groupby(enumerate(residues), lambda x: x[0] - x[1]):
+        group = (map(itemgetter(1), g))
+        group = list(map(int, group))
+        regions.append((group[0], group[-1]))
     return regions
 
 

--- a/mrparse/mr_alphafold.py
+++ b/mrparse/mr_alphafold.py
@@ -37,6 +37,7 @@ class ModelData(object):
         self.rmsd = None
         self.hit = None
         self.region = None
+        self.plddt_regions = None
 
     @property
     def length(self):
@@ -128,7 +129,7 @@ def models_from_hits(hits, pdb_dir=None):
         mlog.model_url = AF_BASE_URL + hit.pdb_id.split('-')[1]
         try:
             mlog.pdb_file, mlog.molecular_weight, \
-            mlog.avg_plddt, mlog.sum_plddt, mlog.h_score, mlog.date_made = prepare_pdb(hit, pdb_dir)
+            mlog.avg_plddt, mlog.sum_plddt, mlog.h_score, mlog.date_made, mlog.plddt_regions = prepare_pdb(hit, pdb_dir)
         except PdbModelException as e:
             logger.critical("Error processing hit pdb %s", e.message)
         models[mlog.name] = mlog
@@ -163,7 +164,7 @@ def prepare_pdb(hit, pdb_dir):
         # SIMBAD currently raises an empty RuntimeError for download problems.
         raise PdbModelException("Error downloading PDB file for: {}".format(hit.pdb_id))
     pdb_file = os.path.join(pdb_dir, pdb_name)
-    pdb_struct.save(pdb_file, remarks=[pdb_struct.structure.make_pdb_headers()])
+    pdb_struct.save(pdb_file)
 
     seqid_range = range(hit.hit_start, hit.hit_stop + 1)
     pdb_struct.select_residues(to_keep_idx=seqid_range)
@@ -171,14 +172,16 @@ def prepare_pdb(hit, pdb_dir):
     avg_plddt = calculate_avg_plddt(pdb_struct.structure)
     sum_plddt = calculate_sum_plddt(pdb_struct.structure)
     h_score = calculate_quality_h_score(pdb_struct.structure)
+    plddt_regions = get_plddt_regions(pdb_struct.structure, hit.seq_ali)
 
     # Convert plddt to bfactor score
     pdb_struct.structure = convert_plddt_to_bfactor(pdb_struct.structure)
 
     truncated_pdb_name = "{}_{}_{}-{}.pdb".format(hit.pdb_id, hit.chain_id, hit.hit_start, hit.hit_stop)
     truncated_pdb_path = os.path.join(MODELS_DIR, truncated_pdb_name)
-    pdb_struct.save(truncated_pdb_path)
-    return truncated_pdb_path, int(pdb_struct.molecular_weight), avg_plddt, sum_plddt, h_score, date_made
+    pdb_struct.save(truncated_pdb_path,
+                    remarks=["PHASER ENSEMBLE MODEL 1 ID {}".format(hit.local_sequence_identity)])
+    return truncated_pdb_path, int(pdb_struct.molecular_weight), avg_plddt, sum_plddt, h_score, date_made, plddt_regions
 
 
 def calculate_quality_threshold(struct, plddt_threshold=70):
@@ -206,6 +209,53 @@ def get_plddt(struct):
         for residue in chain:
             plddt_values.append(residue[0].b_iso)
     return plddt_values
+
+
+def get_plddt_regions(struct, seqid_range):
+    regions = {}
+    plddt_values = get_plddt(struct)
+    residues = zip(seqid_range, plddt_values)
+
+    v_low = []
+    low = []
+    confident = []
+    v_high = []
+
+    for i, plddt in residues:
+        if plddt < 50:
+            v_low.append(i)
+        elif 70 > plddt > 50:
+            low.append(i)
+        elif 90 > plddt > 70:
+            confident.append(i)
+        elif plddt > 90:
+            v_high.append(i)
+
+    regions['v_low'] = _get_regions(v_low)
+    regions['low'] = _get_regions(low)
+    regions['confident'] = _get_regions(confident)
+    regions['v_high'] = _get_regions(v_high)
+
+    return regions
+
+
+def _get_regions(residues):
+    regions = []
+    start = finish = None
+    for i in residues:
+        if start:
+            if i - 1 == finish:
+                finish = i
+            else:
+                regions.append([start, finish])
+                start = i
+                finish = i
+        else:
+            start = i
+            finish = i
+    if start:
+        regions.append([start, finish])
+    return regions
 
 
 def calculate_avg_plddt(struct):

--- a/mrparse/mr_analyse.py
+++ b/mrparse/mr_analyse.py
@@ -1,6 +1,7 @@
 import json
 import multiprocessing
 import os
+import shutil
 import subprocess
 import sys
 
@@ -74,8 +75,10 @@ def run(seqin, hklin=None, run_serial=False, do_classify=True, pdb_dir=None, db_
     html_out = write_output_files(search_model_finder, hkl_info=hkl_info, classifier=classifier, ccp4cloud=ccp4cloud)
     logger.info("Wrote MrParse output file: %s", html_out)
 
-    # Display results in browser
-    if not ccp4cloud:
+    # Clean up files and don't open HTML out if CCP4 cloud
+    if ccp4cloud:
+        shutil.rmtree(pdb_dir)
+    else:
         opencmd = None
         if sys.platform.lower().startswith('linux'):
             opencmd = 'xdg-open'
@@ -175,6 +178,8 @@ def write_output_files(search_model_finder, hkl_info=None, classifier=None, ccp4
         results_dict['pfam'].update(classifier.pfam_dict())
     if hkl_info:
         results_dict['hkl_info'] = hkl_info.as_dict()
+        if ccp4cloud:
+            del results_dict['hkl_info']['hklin']
     results_json = json.dumps(results_dict)
 
     html_out = os.path.abspath(HTML_OUT)

--- a/mrparse/mr_analyse.py
+++ b/mrparse/mr_analyse.py
@@ -25,7 +25,7 @@ logger = None
 
 
 def run(seqin, hklin=None, run_serial=False, do_classify=True, pdb_dir=None, db_lvl=None, tmhmm_exe=None,
-        deepcoil_exe=None):
+        deepcoil_exe=None, ccp4cloud=None):
     # Need to make a work directory first as all logs go into there
     work_dir = make_workdir()
     os.chdir(work_dir)
@@ -71,17 +71,18 @@ def run(seqin, hklin=None, run_serial=False, do_classify=True, pdb_dir=None, db_
 
     #     results_json = get_results_json(search_model_finder, hkl_info=hkl_info, classifier=classifier)
     #     html_out = write_output_files(results_json)
-    html_out = write_output_files(search_model_finder, hkl_info=hkl_info, classifier=classifier)
+    html_out = write_output_files(search_model_finder, hkl_info=hkl_info, classifier=classifier, ccp4cloud=ccp4cloud)
     logger.info("Wrote MrParse output file: %s", html_out)
 
     # Display results in browser
-    opencmd = None
-    if sys.platform.lower().startswith('linux'):
-        opencmd = 'xdg-open'
-    elif sys.platform.lower().startswith('darwin'):
-        opencmd = 'open'
-    if opencmd:
-        subprocess.Popen([opencmd, html_out])
+    if not ccp4cloud:
+        opencmd = None
+        if sys.platform.lower().startswith('linux'):
+            opencmd = 'xdg-open'
+        elif sys.platform.lower().startswith('darwin'):
+            opencmd = 'open'
+        if opencmd:
+            subprocess.Popen([opencmd, html_out])
     return 0
 
 
@@ -139,7 +140,7 @@ def run_analyse_parallel(search_model_finder, classifier, hkl_info, do_classify)
     return search_model_finder, classifier, hkl_info
 
 
-def write_output_files(search_model_finder, hkl_info=None, classifier=None):
+def write_output_files(search_model_finder, hkl_info=None, classifier=None, ccp4cloud=None):
     # write out homologs for CCP4cloud
     # This code should be updated to separate the storing of homologs from the PFAM directives
 
@@ -150,6 +151,9 @@ def write_output_files(search_model_finder, hkl_info=None, classifier=None):
         with open(homologs_js_out, 'w') as w:
             w.write(json.dumps(homologs))
         homologs_pfam = search_model_finder.homologs_with_graphics()
+        if ccp4cloud:
+            for homolog in homologs_pfam:
+                del homolog['pdb_file']
     except RuntimeError:
         logger.debug('No homologues found')
 
@@ -160,6 +164,9 @@ def write_output_files(search_model_finder, hkl_info=None, classifier=None):
         with open(models_js_out, 'w') as w:
             w.write(json.dumps(models))
         models_pfam = search_model_finder.models_with_graphics()
+        if ccp4cloud:
+            for model in models_pfam:
+                del model['pdb_file']
     except RuntimeError:
         logger.debug('No models found')
 

--- a/mrparse/mr_annotation.py
+++ b/mrparse/mr_annotation.py
@@ -1,8 +1,8 @@
-'''
+"""
 Created on 23 Nov 2018
 
 @author: jmht
-'''
+"""
 import copy
 
 
@@ -42,7 +42,6 @@ NULL_ANNOTATION.score = 0.0
 NULL_ANNOTATION.source = 'null'
 
 
-
 class SequenceAnnotation(object):
     def __init__(self, null_symbol=NULL_ANNOTATION.symbol):
         __slots__ = ('source', 'scores', 'annotation', 'annotation_library', 'null_symbol')
@@ -51,24 +50,24 @@ class SequenceAnnotation(object):
         self.annotation = '' # list of annotation symbols
         self.annotation_library = dict()
         self.null_symbol = null_symbol
-    
+
     def add_annotation(self, annotation):
         if annotation != NULL_ANNOTATION:
             assert self.annotation_is_significant(annotation), "Cannot find: %s" % annotation
         self.annotation += annotation.symbol
         self.scores.append(annotation.score)
-    
+
     def annotation_is_significant(self, annotation):
         return annotation is not NULL_ANNOTATION and annotation in self.annotation_library.values()
-    
+
     def has_annotation_symbol(self, symbol):
         return symbol in self.annotation_library
-    
+
     def library_add_annotation(self, annotation):
         assert isinstance(annotation, AnnotationSymbol)
         annotation.source = self.source
         self.annotation_library[annotation.symbol] = annotation
-        
+
     def __getitem__(self, idx):
         symbol = self.annotation[idx]
         if self.has_annotation_symbol(symbol):
@@ -85,11 +84,11 @@ class SequenceAnnotation(object):
             raise TypeError(other)
         assert len(self) == len(other)
         ca = self.__class__() # Class holding consensus annotation
-        
+
         # Combine annotation_libraries - is it worth removing those entries that aren't
         # included in the consensus?
         ca.annotation_library = dict(self.annotation_library, **other.annotation_library)
-        
+
         # For now just use prediction and leave probabiltiies
         for i in range(len(self)):
             if self.annotation_is_significant(self[i]) and other.annotation_is_significant(other[i]):
@@ -100,7 +99,7 @@ class SequenceAnnotation(object):
                 ca.add_annotation(other[i])
             else:
                 ca.add_annotation(NULL_ANNOTATION)
-        return ca        
+        return ca
 
     def __len__(self):
         return len(self.annotation)
@@ -112,14 +111,14 @@ class SequenceAnnotation(object):
         for a in sorted(attrs):
             out_str += INDENT + "{} : {}\n".format(a, self.__dict__[a])
         return out_str
-        
+
 
 class AnnotationChunk(object):
     def __init__(self, start=None, end=None, annotation=None):
         self.start = start
         self.end = end
         self.annotation = annotation
-    
+
     def __str__(self):
         attrs = [k for k in self.__dict__.keys() if not k.startswith('_')]
         INDENT = "  "
@@ -127,8 +126,8 @@ class AnnotationChunk(object):
         for a in sorted(attrs):
             out_str += INDENT + "{} : {}\n".format(a, self.__dict__[a])
         return out_str
-    
-    
+
+
 def get_annotation_chunks(annotation):
     if annotation is None:
         return None

--- a/mrparse/mr_args.py
+++ b/mrparse/mr_args.py
@@ -40,6 +40,7 @@ def parse_command_line():
                         help="Location of TMHMM executable for transmembrane classification")
     parser.add_argument('--deepcoil_exe', action=FilePathAction,
                         help="Location of Deepcoil executable for coiled-coil classification")
+    parser.add_argument('--ccp4cloud', action='store_true', help="specify running through CCP4Cloud")
     parser.add_argument('-v', '--version', action='version', version='%(prog)s version: ' + __version__)
     args = parser.parse_args()
 

--- a/mrparse/mr_hit.py
+++ b/mrparse/mr_hit.py
@@ -27,6 +27,7 @@ class SequenceHit:
         self.evalue = 0.0
         self.pvalue = 0.0
         self.score = 0.0
+        self.seq_ali = None
         self.alignment = ""
         self.query_start = None 
         self.query_stop = None
@@ -138,6 +139,8 @@ def _find_hits(logfile=None, searchio_type=None, target_sequence=None):
             hstart = hsp.hit_start
             hstop = hsp.hit_end
             qstart, qstop = hsp.query_range
+            seq_ali = zip(range(qstart, qstop), hsp.hit.seq)
+            sh.seq_ali = [x[0] for x in seq_ali if x[1] != '-']
             sh.query_start = qstart
             sh.query_stop = qstop
             sh.hit_start = hstart

--- a/mrparse/mr_homolog.py
+++ b/mrparse/mr_homolog.py
@@ -161,7 +161,7 @@ def prepare_pdb(hit, pdb_dir):
         except RuntimeError:
             # SIMBAD currently raises an empty RuntimeError for download problems.
             raise PdbModelException("Error downloading PDB file for: {}".format(hit.pdb_id))
-        pdb_struct.save(pdb_file, remarks=[pdb_struct.structure.make_pdb_headers()])
+        pdb_struct.save(pdb_file)
     
     resolution = pdb_struct.structure.resolution
         
@@ -172,7 +172,8 @@ def prepare_pdb(hit, pdb_dir):
     pdb_struct.select_residues(to_keep_idx=seqid_range)
     truncated_pdb_name = "{}_{}_{}-{}.pdb".format(hit.pdb_id, hit.chain_id, hit.hit_start, hit.hit_stop)
     truncated_pdb_path = os.path.join(HOMOLOGS_DIR, truncated_pdb_name)
-    pdb_struct.save(truncated_pdb_path)
+    pdb_struct.save(truncated_pdb_path,
+                    remarks=["PHASER ENSEMBLE MODEL 1 ID {}".format(hit.local_sequence_identity)])
     return truncated_pdb_path, int(round(pdb_struct.molecular_weight)), resolution
 
 

--- a/mrparse/mr_pfam.py
+++ b/mrparse/mr_pfam.py
@@ -77,8 +77,7 @@ def add_pfam_dict_to_models(models, sequence_length):
                   "v_high": "0053d6"}
         for quality in plddt_regions.keys():
             for plddt_region in plddt_regions[quality]:
-                plddt_region_start = plddt_region[0]
-                plddt_region_end = plddt_region[1]
+                plddt_region_start, plddt_region_end = plddt_region
                 md = {'colour': colors[quality],
                       'metadata': {"description": quality,
                                    "database": "EBI AlphaFold database",

--- a/mrparse/mr_pfam.py
+++ b/mrparse/mr_pfam.py
@@ -52,24 +52,50 @@ def add_pfam_dict_to_models(models, sequence_length):
     # Need a better way of getting the number of regions
     for m in models.values():
         start = m.query_start
-        stop = m.query_stop
+        stop = m.query_stop + 1
         name = m.name
         region_id = m.region_id
+        plddt_regions = m.plddt_regions
+        # 'colour': '#193f90'
         d = {'startStyle': "curved",
              'endStyle': "curved",
              'start': start,
              'end': stop,
              'aliStart': start,
              'aliEnd': stop,
-             'colour': '#193f90',
-             'text': name,
+             'colour': '#d3d3d3',
+             'text': "",
              'metadata': {"description": "Model {} from region #{}".format(name, region_id),
                           "database": "EBI AlphaFold database",
                           "start": start,
                           "end": stop}
              }
+        motifs = []
+        colors = {'v_low': "ff7d45",
+                  "low": "ffdb13",
+                  "confident": "65cbf3",
+                  "v_high": "0053d6"}
+        for quality in plddt_regions.keys():
+            for plddt_region in plddt_regions[quality]:
+                plddt_region_start = plddt_region[0]
+                plddt_region_end = plddt_region[1]
+                md = {'colour': colors[quality],
+                      'metadata': {"description": quality,
+                                   "database": "EBI AlphaFold database",
+                                   "type": "Quality",
+                                   "end": plddt_region_end,
+                                   "start": plddt_region_start},
+                      "type": "pLDDT",
+                      "display": "true",
+                      "end": plddt_region_end,
+                      "start": plddt_region_start
+                      }
+                motifs.append(md)
+
         jdict = {'length': sequence_length,
-                 'regions': [d]}
+                 'regions': [d],
+                 'motifs': motifs
+                 }
         m._pfam_json = jdict
 
 

--- a/mrparse/mr_sequence.py
+++ b/mrparse/mr_sequence.py
@@ -10,10 +10,11 @@ import os
 from Bio.Seq import Seq
 from Bio import SeqIO
 from Bio.SeqUtils import molecular_weight
-from Bio.Alphabet import IUPAC
+from Bio.Alphabet import generic_protein
 from Bio.SeqRecord import SeqRecord
 
-SUFFIX_TO_TYPE = {'fasta': 'fasta'}
+SUFFIX_TO_TYPE = {'fasta': 'fasta',
+                  'pir': 'pir'}
 
 
 class MultipleSequenceException(Exception):
@@ -30,7 +31,7 @@ class Sequence(object):
         if seq_file:
             self._read_sequence_file(seq_file, sequence_type)
         elif sequence:
-            self._bio_seq = Seq(sequence, IUPAC.protein)
+            self._bio_seq = Seq(sequence, generic_protein)
             self._bio_seq_record = SeqRecord(self._bio_seq)
         self.nresidues = len(self._bio_seq)
         self.sequence = str(self._bio_seq)
@@ -48,7 +49,7 @@ class Sequence(object):
                 raise RuntimeError("Cannot determine sequence type from file: {}".format(seq_file))
 
         try:
-            self._bio_seq_record = SeqIO.read(seq_file, sequence_type, alphabet=IUPAC.protein)
+            self._bio_seq_record = SeqIO.read(seq_file, sequence_type, alphabet=generic_protein)
             self._bio_seq = self._bio_seq_record.seq
         except ValueError:
             raise MultipleSequenceException
@@ -122,7 +123,7 @@ def merge_multiple_sequences(seq_file):
     sequence = ""
     identifier = []
     previous_seqs = []
-    for seq in SeqIO.parse(seq_file, sequence_type, alphabet=IUPAC.protein):
+    for seq in SeqIO.parse(seq_file, sequence_type, alphabet=generic_protein):
         if seq.seq in previous_seqs:
             continue
         sequence += seq.seq

--- a/mrparse/mr_version.py
+++ b/mrparse/mr_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 2, 0)
+__version_info__ = (0, 2, 1)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/test_mr_alphafold.py
+++ b/tests/test_mr_alphafold.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env ccp4-python
 import set_mrparse_path
 import pytest
+import gemmi
 import logging
-from mrparse.mr_alphafold import models_from_hits, calculate_quality_threshold, calculate_quality_h_score, \
+from mrparse.mr_alphafold import download_model, models_from_hits, calculate_quality_threshold, calculate_quality_h_score, \
     calculate_avg_plddt, calculate_sum_plddt
 from simbad.util.pdb_util import PdbStructure
 
@@ -22,12 +23,19 @@ def test_2uvoA_models(test_data, get_2uvo_alphafold_test_hits):
     assert int(m.sum_plddt) == 16187
 
 
-def test_calculate_quality_scores(test_data, get_2uvo_alphafold_test_hits):
+def test_calculate_quality_scores(get_2uvo_alphafold_test_hits):
     """Test the quality scoring methods"""
     hits = get_2uvo_alphafold_test_hits
-    models = models_from_hits(hits, pdb_dir=test_data.pdb_dir)
-    m = models['Q0JF21_1']
-    pdb_struct = PdbStructure().from_file(m.pdb_file)
+    hit = hits['AFDB:AF-Q0JF21-F1_1']
+
+    pdb_name = "{}-model_v1.pdb".format(hit.pdb_id.split(":")[1])
+    pdb_struct = PdbStructure()
+    pdb_string = download_model(pdb_name)
+    pdb_struct.structure = gemmi.read_pdb_string(pdb_string)
+    models = [m.name for m in pdb_struct.structure]
+    del pdb_struct.structure[models[0]]
+    seqid_range = range(hit.hit_start, hit.hit_stop + 1)
+    pdb_struct.select_residues(to_keep_idx=seqid_range)
 
     threshold = calculate_quality_threshold(pdb_struct.structure)
     threshold_2 = calculate_quality_threshold(pdb_struct.structure, plddt_threshold=95)

--- a/tests/test_mr_sequence.py
+++ b/tests/test_mr_sequence.py
@@ -5,7 +5,7 @@ import conftest
 import os
 from mrparse.mr_sequence import Sequence, merge_multiple_sequences
 from Bio import SeqIO
-from Bio.Alphabet import IUPAC
+from Bio.Alphabet import generic_protein
 import data_constants
 
 
@@ -21,7 +21,7 @@ def test_2uvo_write(test_data):
     filename = 'foo.fasta'
     seq_info.write(filename)
     assert os.path.isfile(filename)
-    s = SeqIO.read(filename, 'fasta', alphabet=IUPAC.protein)
+    s = SeqIO.read(filename, 'fasta', alphabet=generic_protein)
     assert len(s) == 171
     os.unlink(filename)
     
@@ -32,7 +32,7 @@ def test_2uvo_write_description(test_data):
     description = 'foo'
     seq_info.write(filename, description=description)
     assert os.path.isfile(filename)
-    s = SeqIO.read(filename, 'fasta', alphabet=IUPAC.protein)
+    s = SeqIO.read(filename, 'fasta', alphabet=generic_protein)
     assert len(s) == 171
     assert s.description == description
     os.unlink(filename)
@@ -50,7 +50,7 @@ def test_2uvo_seq_write():
     filename = 'foo.fasta'
     seq_info.write(filename)
     assert os.path.isfile(filename)
-    s = SeqIO.read(filename, 'fasta', alphabet=IUPAC.protein)
+    s = SeqIO.read(filename, 'fasta', alphabet=generic_protein)
     assert len(s) == 171
     os.unlink(filename)
 
@@ -59,6 +59,7 @@ def test_5hxg_seq(test_data):
     seq_info = merge_multiple_sequences(seq_file=test_data.x5hxg_fasta)
     assert seq_info.nresidues == 351
     assert seq_info.sequence == data_constants.FIVEHXG_SEQ
+
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
- ccp4 cloud specific changes, --ccp4cloud flag added that stops results page popping up and deletes unwanted files and stops local file locations being shown in the output results page. 
- Added in B-factor conversion for pLDDT scores and a sequence identity header used in MR with phaser.
- Added in coloured pfam domains where the colour corresponds to the pLDDT confidence score. 