### PR TITLE
Bigafdb

### DIFF
--- a/data/mrparse.config
+++ b/data/mrparse.config
@@ -11,6 +11,5 @@ hhsearch_exe = hhsearch
 
 [Databases]
 hhsearch_db = None
-afdb_seqdb = None
 afdb_version = v2
 

--- a/mrparse/__main__.py
+++ b/mrparse/__main__.py
@@ -29,7 +29,8 @@ def main():
                               afdb_seqdb=args.afdb_seqdb,
                               ccp4cloud=args.ccp4cloud,
                               run_local=args.run_local,
-                              max_hits=args.max_hits)
+                              max_hits=args.max_hits,
+                              nproc=args.nproc)
     except KeyboardInterrupt:
         sys.stderr.write("Interrupted by keyboard!")
         return 0

--- a/mrparse/__main__.py
+++ b/mrparse/__main__.py
@@ -19,6 +19,7 @@ def main():
                               run_serial=args.run_serial,
                               do_classify=args.do_classify,
                               pdb_dir=args.pdb_dir,
+                              pdb_local=args.pdb_local,
                               phmmer_dblvl=args.phmmer_dblvl,
                               plddt_cutoff=args.plddt_cutoff,
                               search_engine=args.search_engine,

--- a/mrparse/__main__.py
+++ b/mrparse/__main__.py
@@ -27,7 +27,9 @@ def main():
                               hhsearch_exe=args.hhsearch_exe,
                               hhsearch_db=args.hhsearch_db,
                               afdb_seqdb=args.afdb_seqdb,
-                              ccp4cloud=args.ccp4cloud)
+                              ccp4cloud=args.ccp4cloud,
+                              run_local=args.run_local,
+                              max_hits=args.max_hits)
     except KeyboardInterrupt:
         sys.stderr.write("Interrupted by keyboard!")
         return 0

--- a/mrparse/__main__.py
+++ b/mrparse/__main__.py
@@ -29,7 +29,7 @@ def main():
                               hhsearch_db=args.hhsearch_db,
                               afdb_seqdb=args.afdb_seqdb,
                               ccp4cloud=args.ccp4cloud,
-                              run_local=args.run_local,
+                              use_api=args.use_api,
                               max_hits=args.max_hits,
                               nproc=args.nproc)
     except KeyboardInterrupt:

--- a/mrparse/html/mrparse.html.jinja2
+++ b/mrparse/html/mrparse.html.jinja2
@@ -52,7 +52,7 @@
 <body style="margin:1%;font-family:'Lato'">
   <div style="background-color:#efefef;color:#3b3b3dff;padding:20px">
   <h1>MrParse Analysis</h1>
-  <h3>Version: 0.3.3</h3>
+  <h3>Version: 0.3.5</h3>
   <p>MrParse: a program to find and analyse search models for crystallographic Molecular Replacement.
   The program is being developed by <a href="https://www.liverpool.ac.uk/integrative-biology/staff/daniel-rigden/"
   target="_blank">Dan Rigden's group</a> at the University of Liverpool.</p>

--- a/mrparse/mr_alphafold.py
+++ b/mrparse/mr_alphafold.py
@@ -131,7 +131,7 @@ def models_from_hits(hits, plddt_cutoff):
         mlog = ModelData()
         mlog.hit = hit
         hit._homolog = mlog
-        mlog.model_url = AF_BASE_URL + (hit.pdb_id.split("-")[0] + "-" + hit.pdb_id.split("-")[1])
+        mlog.model_url = AF_BASE_URL + hit.pdb_id + "-model_" + db_ver + ".pdb"
         try:
             mlog.pdb_file, mlog.molecular_weight, \
             mlog.avg_plddt, mlog.sum_plddt, mlog.h_score, \
@@ -159,7 +159,6 @@ def prepare_pdb(hit, plddt_cutoff, database_version):
 
     print("Retrieving and preparing model: %s" % hit.name)
 
-    #pdb_name = f"AF-{hit.pdb_id}-F1-model_{database_version}.pdb"
     pdb_name = f"{hit.pdb_id}-model_{database_version}.pdb"
     pdb_struct = PdbStructure()
     try:

--- a/mrparse/mr_alphafold.py
+++ b/mrparse/mr_alphafold.py
@@ -131,7 +131,7 @@ def models_from_hits(hits, plddt_cutoff):
         mlog = ModelData()
         mlog.hit = hit
         hit._homolog = mlog
-        mlog.model_url = AF_BASE_URL + hit.pdb_id
+        mlog.model_url = AF_BASE_URL + (hit.pdb_id.split("-")[0] + "-" + hit.pdb_id.split("-")[1])
         try:
             mlog.pdb_file, mlog.molecular_weight, \
             mlog.avg_plddt, mlog.sum_plddt, mlog.h_score, \

--- a/mrparse/mr_alphafold.py
+++ b/mrparse/mr_alphafold.py
@@ -156,6 +156,9 @@ def prepare_pdb(hit, plddt_cutoff, database_version):
     trucate to required residues
     calculate the MW
     """
+
+    print("Retrieving and preparing model: %s" % hit.name)
+
     #pdb_name = f"AF-{hit.pdb_id}-F1-model_{database_version}.pdb"
     pdb_name = f"{hit.pdb_id}-model_{database_version}.pdb"
     pdb_struct = PdbStructure()

--- a/mrparse/mr_alphafold.py
+++ b/mrparse/mr_alphafold.py
@@ -156,7 +156,8 @@ def prepare_pdb(hit, plddt_cutoff, database_version):
     trucate to required residues
     calculate the MW
     """
-    pdb_name = f"AF-{hit.pdb_id}-F1-model_{database_version}.pdb"
+    #pdb_name = f"AF-{hit.pdb_id}-F1-model_{database_version}.pdb"
+    pdb_name = f"{hit.pdb_id}-model_{database_version}.pdb"
     pdb_struct = PdbStructure()
     try:
         pdb_string = download_model(pdb_name)

--- a/mrparse/mr_analyse.py
+++ b/mrparse/mr_analyse.py
@@ -42,6 +42,7 @@ def run(seqin, **kwargs):
     ccp4cloud = kwargs.get('ccp4cloud', None)
     run_local = kwargs.get('run_local', None)
     max_hits = kwargs.get('max_hits', 10)
+    nproc = kwargs.get('nproc', 1)
 
     # Need to make a work directory first as all logs go into there
     work_dir = make_workdir()
@@ -81,7 +82,7 @@ def run(seqin, **kwargs):
     search_model_finder = SearchModelFinder(seq_info, hkl_info=hkl_info, pdb_dir=pdb_dir, phmmer_dblvl=phmmer_dblvl,
                                             plddt_cutoff=plddt_cutoff, search_engine=search_engine,
                                             hhsearch_exe=hhsearch_exe, hhsearch_db=hhsearch_db, afdb_seqdb=afdb_seqdb, 
-                                            run_local=run_local, max_hits=max_hits)
+                                            run_local=run_local, max_hits=max_hits, nproc=nproc)
 
     classifier = None
     if do_classify:

--- a/mrparse/mr_analyse.py
+++ b/mrparse/mr_analyse.py
@@ -31,6 +31,7 @@ def run(seqin, **kwargs):
     run_serial = kwargs.get('run_serial', None)
     do_classify = kwargs.get('do_classify', None)
     pdb_dir = kwargs.get('pdb_dir', None)
+    pdb_local = kwargs.get('pdb_local', None)
     phmmer_dblvl = kwargs.get('phmmer_dblvl', '95')
     plddt_cutoff = kwargs.get('plddt_cutoff', '70')
     search_engine = kwargs.get('search_engine', 'phmmer')
@@ -82,7 +83,7 @@ def run(seqin, **kwargs):
     search_model_finder = SearchModelFinder(seq_info, hkl_info=hkl_info, pdb_dir=pdb_dir, phmmer_dblvl=phmmer_dblvl,
                                             plddt_cutoff=plddt_cutoff, search_engine=search_engine,
                                             hhsearch_exe=hhsearch_exe, hhsearch_db=hhsearch_db, afdb_seqdb=afdb_seqdb, 
-                                            run_local=run_local, max_hits=max_hits, nproc=nproc)
+                                            run_local=run_local, max_hits=max_hits, nproc=nproc, pdb_local=pdb_local)
 
     classifier = None
     if do_classify:

--- a/mrparse/mr_analyse.py
+++ b/mrparse/mr_analyse.py
@@ -41,7 +41,7 @@ def run(seqin, **kwargs):
     hhsearch_db = kwargs.get('hhsearch_db', None)
     afdb_seqdb = kwargs.get('afdb_seqdb', None)
     ccp4cloud = kwargs.get('ccp4cloud', None)
-    run_local = kwargs.get('run_local', None)
+    use_api = kwargs.get('use_api', None)
     max_hits = kwargs.get('max_hits', 10)
     nproc = kwargs.get('nproc', 1)
 
@@ -83,7 +83,7 @@ def run(seqin, **kwargs):
     search_model_finder = SearchModelFinder(seq_info, hkl_info=hkl_info, pdb_dir=pdb_dir, phmmer_dblvl=phmmer_dblvl,
                                             plddt_cutoff=plddt_cutoff, search_engine=search_engine,
                                             hhsearch_exe=hhsearch_exe, hhsearch_db=hhsearch_db, afdb_seqdb=afdb_seqdb, 
-                                            run_local=run_local, max_hits=max_hits, nproc=nproc, pdb_local=pdb_local)
+                                            use_api=use_api, max_hits=max_hits, nproc=nproc, pdb_local=pdb_local)
 
     classifier = None
     if do_classify:

--- a/mrparse/mr_analyse.py
+++ b/mrparse/mr_analyse.py
@@ -40,6 +40,8 @@ def run(seqin, **kwargs):
     hhsearch_db = kwargs.get('hhsearch_db', None)
     afdb_seqdb = kwargs.get('afdb_seqdb', None)
     ccp4cloud = kwargs.get('ccp4cloud', None)
+    run_local = kwargs.get('run_local', None)
+    max_hits = kwargs.get('max_hits', 10)
 
     # Need to make a work directory first as all logs go into there
     work_dir = make_workdir()
@@ -78,7 +80,8 @@ def run(seqin, **kwargs):
 
     search_model_finder = SearchModelFinder(seq_info, hkl_info=hkl_info, pdb_dir=pdb_dir, phmmer_dblvl=phmmer_dblvl,
                                             plddt_cutoff=plddt_cutoff, search_engine=search_engine,
-                                            hhsearch_exe=hhsearch_exe, hhsearch_db=hhsearch_db, afdb_seqdb=afdb_seqdb)
+                                            hhsearch_exe=hhsearch_exe, hhsearch_db=hhsearch_db, afdb_seqdb=afdb_seqdb, 
+                                            run_local=run_local, max_hits=max_hits)
 
     classifier = None
     if do_classify:

--- a/mrparse/mr_args.py
+++ b/mrparse/mr_args.py
@@ -43,11 +43,11 @@ def mrparse_argparse(parser):
     sg.add_argument('--hhsearch_exe', action=FilePathAction,
                     help="Location of hhsearch executable")
     sg.add_argument('--hhsearch_db', help="Location of hhsearch database")
-    sg.add_argument('--afdb_seqdb', help="Location of alphafold sequence database")
-    sg.add_argument('--ccp4cloud', action='store_true', help="specify running through CCP4Cloud")
-    sg.add_argument('--use_api', action='store_true', help='run searches using locally stored databases only')
-    sg.add_argument('--max_hits', required=False, type=int, choices=range(1,101), metavar="[1-100]", default=10, help='maximum number of models to download and prepare for each database search')
-    sg.add_argument('--nproc', required=False, type=int, default=1, help='number of cores to use in phmmer search')
+    sg.add_argument('--afdb_seqdb', help="Location of alternative alphafold sequence database. To search the entire alphafold database, download the latest sequence listing here: https://ftp.ebi.ac.uk/pub/databases/alphafold/sequences.fasta and set path to file using this option. Note: very large file size!")
+    sg.add_argument('--ccp4cloud', action='store_true', help="Specify running through CCP4Cloud")
+    sg.add_argument('--use_api', action='store_true', help='Run alphafold database search using EBI API database search')
+    sg.add_argument('--max_hits', required=False, type=int, choices=range(1,101), metavar="[1-100]", default=10, help='Maximum number of models to download and prepare for each database search')
+    sg.add_argument('--nproc', required=False, type=int, default=1, help='Number of cores to use in phmmer search')
     sg.add_argument('-v', '--version', action='version', version='%(prog)s version: ' + __version__)
 
 

--- a/mrparse/mr_args.py
+++ b/mrparse/mr_args.py
@@ -27,6 +27,7 @@ def mrparse_argparse(parser):
     sg.add_argument('--do_classify', action='store_true',
                     help='Run the SS/TM/CC classifiers - requires internet access.')
     sg.add_argument('--pdb_dir', action=FilePathAction, help='Directory of PDB files')
+    sg.add_argument('--pdb_local', action=FilePathAction, help='Path to locally stored PDB mirror')
     sg.add_argument('--phmmer_dblvl', help='Redundancy level of PDB database used by Phmmer', default='95',
                     choices=['50', '70', '90', '95', '100'])
     sg.add_argument('--plddt_cutoff', help='Removes residues from AFDB models below this pLDDT threshold',

--- a/mrparse/mr_args.py
+++ b/mrparse/mr_args.py
@@ -44,6 +44,8 @@ def mrparse_argparse(parser):
     sg.add_argument('--hhsearch_db', help="Location of hhsearch database")
     sg.add_argument('--afdb_seqdb', help="Location of alphafold sequence database")
     sg.add_argument('--ccp4cloud', action='store_true', help="specify running through CCP4Cloud")
+    sg.add_argument('--run_local', action='store_true', help='run searches using locally stored databases only')
+    sg.add_argument('--max_hits', required=False, type=int, choices=range(1,101), metavar="[1-100]", default=10, help='maximum number of models to download and prepare for each database search')
     sg.add_argument('-v', '--version', action='version', version='%(prog)s version: ' + __version__)
 
 

--- a/mrparse/mr_args.py
+++ b/mrparse/mr_args.py
@@ -46,6 +46,7 @@ def mrparse_argparse(parser):
     sg.add_argument('--ccp4cloud', action='store_true', help="specify running through CCP4Cloud")
     sg.add_argument('--run_local', action='store_true', help='run searches using locally stored databases only')
     sg.add_argument('--max_hits', required=False, type=int, choices=range(1,101), metavar="[1-100]", default=10, help='maximum number of models to download and prepare for each database search')
+    sg.add_argument('--nproc', required=False, type=int, default=1, help='number of cores to use in phmmer search')
     sg.add_argument('-v', '--version', action='version', version='%(prog)s version: ' + __version__)
 
 

--- a/mrparse/mr_args.py
+++ b/mrparse/mr_args.py
@@ -82,9 +82,9 @@ def parse_command_line():
     if args.hhsearch_db != defaults['hhsearch_db']:
         config.set('Databases', 'hhsearch_db', args.hhsearch_db)
         update_config = True
-    if args.afdb_seqdb != defaults['afdb_seqdb']:
-        config.set('Databases', 'afdb_seqdb', args.afdb_seqdb)
-        update_config = True
+    #if args.afdb_seqdb != defaults['afdb_seqdb']:
+    #    config.set('Databases', 'afdb_seqdb', args.afdb_seqdb)
+    #    update_config = True
     if update_config:
         with open(config_file, 'w') as f:
             config.write(f)

--- a/mrparse/mr_args.py
+++ b/mrparse/mr_args.py
@@ -45,7 +45,7 @@ def mrparse_argparse(parser):
     sg.add_argument('--hhsearch_db', help="Location of hhsearch database")
     sg.add_argument('--afdb_seqdb', help="Location of alphafold sequence database")
     sg.add_argument('--ccp4cloud', action='store_true', help="specify running through CCP4Cloud")
-    sg.add_argument('--run_local', action='store_true', help='run searches using locally stored databases only')
+    sg.add_argument('--use_api', action='store_true', help='run searches using locally stored databases only')
     sg.add_argument('--max_hits', required=False, type=int, choices=range(1,101), metavar="[1-100]", default=10, help='maximum number of models to download and prepare for each database search')
     sg.add_argument('--nproc', required=False, type=int, default=1, help='number of cores to use in phmmer search')
     sg.add_argument('-v', '--version', action='version', version='%(prog)s version: ' + __version__)

--- a/mrparse/mr_hit.py
+++ b/mrparse/mr_hit.py
@@ -179,11 +179,11 @@ def _find_hits(logfile=None, searchio_type=None, target_sequence=None, af2=False
     
             if af2:
                 sh.score = phr.resultsDict[hitname].score
-                hit_name = phr.resultsDict[hitname].afdbName + "_" + str(phr.resultsDict[hitname].domainID)
+                hit_name = phr.resultsDict[hitname].afdbName # + "_" + str(phr.resultsDict[hitname].domainID)
                 sh.search_engine = "phmmer"
             elif searchio_type == "hmmer3-text":
                 sh.score = phr.resultsDict[hitname].score
-                hit_name = phr.resultsDict[hitname].afdbName + "_" + phr.resultsDict[hitname].chainID + "_" + str(phr.resultsDict[hitname].domainID)
+                hit_name = phr.resultsDict[hitname].afdbName + "_" + phr.resultsDict[hitname].chainID # + "_" + str(phr.resultsDict[hitname].domainID)
                 sh.search_engine = "phmmer"
             sh.name = hit_name
             if sh.rank <= max_hits:

--- a/mrparse/mr_hit.py
+++ b/mrparse/mr_hit.py
@@ -99,17 +99,21 @@ class SequenceHit:
         return out_str
 
 
-def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=None, phmmer_dblvl=95):
+def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=None, phmmer_dblvl=95, localrun=False, max_hits=10):
     target_sequence = seq_info.sequence
     af2 = False
     if search_engine == PHMMER:
-        if phmmer_dblvl == "af2":
-            try:
-                json_file = run_phmmer_alphafold_api(seq_info)
-                hits = _find_json_hits(json_file, target_sequence=seq_info)
-                return hits
-            except json.JSONDecodeError:
-                logger.debug("Phmmer API unavailable, running local phmmer search of AFDB")
+        if not localrun:
+            if phmmer_dblvl == "af2":
+                try:
+                    json_file = run_phmmer_alphafold_api(seq_info)
+                    hits = _find_json_hits(json_file, target_sequence=seq_info, max_hits=max_hits)
+                    return hits
+                except json.JSONDecodeError:
+                    logger.debug("Phmmer API unavailable, running local phmmer search of AFDB")
+                    af2 = True
+        else:
+            if phmmer_dblvl == "af2":
                 af2 = True
         logfile = run_phmmer(seq_info, afdb_seqdb=afdb_seqdb, dblvl=phmmer_dblvl)
         searchio_type = 'hmmer3-text'
@@ -118,72 +122,121 @@ def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=Non
         logfile = run_hhsearch(seq_info, hhsearch_exe, hhsearch_db)
     else:
         raise RuntimeError(f"Unrecognised search_engine: {search_engine}")
-    return _find_hits(logfile=logfile, searchio_type=searchio_type, target_sequence=target_sequence, af2=af2)
+    return _find_hits(logfile=logfile, searchio_type=searchio_type, target_sequence=target_sequence, af2=af2, max_hits=max_hits)
 
 
-def _find_hits(logfile=None, searchio_type=None, target_sequence=None, af2=False):
+def _find_hits(logfile=None, searchio_type=None, target_sequence=None, af2=False, max_hits=10):
     assert logfile and searchio_type and target_sequence
 
-    if af2:
-        fix_af_phmmer_log(logfile, "phmmer_af2_fixed.log")
-        logfile = "phmmer_af2_fixed.log"
-
-    try:
-        io = SearchIO.read(logfile, searchio_type)
-    except ValueError:
-        logger.exception("ValueError while running Biopython")
-        raise RuntimeError('Problem running Biopython SearchIO - you may need to update your version of Biopython.')
-    except:
-        logger.exception("Unexpected error while running Biopython")
-        raise
-
-    included = io.hit_filter(lambda x: x.is_included)
     hitDict = OrderedDict()
-    for i, hit in enumerate(included):
-        rank = i + 1
-        for hsp in hit.hsps:
+    if af2 or searchio_type == "hmmer3-text":
+        if af2:
+            fix_af_phmmer_log(logfile, "phmmer_af2_fixed.log")
+            logfile = "phmmer_af2_fixed.log"
+    
+        # Read logfile with searchDB
+        from mrparse.searchDB import Phmmer  
+    
+        plog=open(logfile, "r")
+        phmmerALNLog=plog.readlines()
+        plog.close()
+    
+        phr=Phmmer()
+        phr.logfile=logfile
+        if af2:
+            phr.getPhmmerAlignments(targetSequence=target_sequence, phmmerALNLog=phmmerALNLog, PDBLOCAL=None, DB='AFDB', seqMetaDB=None)
+        else:
+            phr.getPhmmerAlignments(targetSequence=target_sequence, phmmerALNLog=phmmerALNLog, PDBLOCAL=None, DB='PDB', seqMetaDB=None)
+        for hitname in (phr.resultsDict):
+    
             sh = SequenceHit()
-            sh.rank = rank
+            sh.rank = phr.resultsDict[hitname].rank
             if af2:
-                sh.pdb_id = hsp.hit_id.split("-")[1]
+                sh.pdb_id = phr.resultsDict[hitname].afdbName
             else:
-                sh.pdb_id, sh.chain_id = hsp.hit_id.split('_')
-            sh.evalue = hsp.evalue  # is i-Evalue - possibly evalue_cond in later BioPython
-            hstart = hsp.hit_start
-            hstop = hsp.hit_end
-            qstart, qstop = hsp.query_range
-            seq_ali = zip(range(qstart, qstop), hsp.hit.seq)
+                sh.pdb_id, sh.chain_id = phr.resultsDict[hitname].afdbName, phr.resultsDict[hitname].chainID
+    
+            sh.evalue = phr.resultsDict[hitname].evalue
+    
+            sh.query_start = phr.resultsDict[hitname].tarRange[0]
+            sh.query_stop = phr.resultsDict[hitname].tarRange[1]
+            sh.hit_start = int(phr.resultsDict[hitname].alnRange.split("-")[0])
+            sh.hit_stop = int(phr.resultsDict[hitname].alnRange.split("-")[1])
+            sh.target_alignment = phr.resultsDict[hitname].targetAlignment
+            sh.alignment = phr.resultsDict[hitname].alignment
+
+            hstart = sh.hit_start
+            hstop = sh.hit_stop
+            qstart, qstop = sh.query_start, sh.query_stop
+    
+            seq_ali = zip(range(qstart, qstop), sh.alignment)
             sh.seq_ali = [x[0] for x in seq_ali if x[1] != '-']
-            sh.query_start = qstart
-            sh.query_stop = qstop
-            sh.hit_start = hstart
-            sh.hit_stop = hstop
-            target_alignment = "".join(hsp.aln[0].upper())  # assume the first Sequence is always the target
-            sh.target_alignment = target_alignment
-            alignment = "".join(hsp.aln[1].upper())  # assume the first Sequence is always the target
-            sh.alignment = alignment
-            local, overall = simpleSeqID().getPercent(alignment, target_alignment, target_sequence)
+    
+            local, overall = phr.resultsDict[hitname].localSEQID, phr.resultsDict[hitname].overallSEQID
             sh.local_sequence_identity = np.round(local)
             sh.overall_sequence_identity = np.round(overall)
-
+    
             if af2:
-                sh.score = hit.bitscore
-                hit_name = hit.id.split('-')[1] + "_" + str(hsp.domain_index)
+                sh.score = phr.resultsDict[hitname].score
+                hit_name = phr.resultsDict[hitname].afdbName + "_" + str(phr.resultsDict[hitname].domainID)
                 sh.search_engine = "phmmer"
             elif searchio_type == "hmmer3-text":
-                sh.score = hit.bitscore
-                hit_name = hit.id + "_" + str(hsp.domain_index)
+                sh.score = phr.resultsDict[hitname].score
+                hit_name = phr.resultsDict[hitname].afdbName + "_" + phr.resultsDict[hitname].chainID + "_" + str(phr.resultsDict[hitname].domainID)
                 sh.search_engine = "phmmer"
-            else:
+            sh.name = hit_name
+            if sh.rank <= max_hits:
+                hitDict[hit_name] = sh
+        
+    else:
+        try:
+            io = SearchIO.read(logfile, searchio_type)
+        except ValueError:
+            logger.exception("ValueError while running Biopython")
+            raise RuntimeError('Problem running Biopython SearchIO - you may need to update your version of Biopython.')
+        except:
+            logger.exception("Unexpected error while running Biopython")
+            raise
+    
+        included = io.hit_filter(lambda x: x.is_included)
+        for i, hit in enumerate(included):
+            rank = i + 1
+            for hsp in hit.hsps:
+                sh = SequenceHit()
+                sh.rank = rank
+                if af2:
+                    sh.pdb_id = hsp.hit_id.split("-")[1]
+                else:
+                    sh.pdb_id, sh.chain_id = hsp.hit_id.split('_')
+                sh.evalue = hsp.evalue  # is i-Evalue - possibly evalue_cond in later BioPython
+                hstart = hsp.hit_start
+                hstop = hsp.hit_end
+                qstart, qstop = hsp.query_range
+                seq_ali = zip(range(qstart, qstop), hsp.hit.seq)
+                sh.seq_ali = [x[0] for x in seq_ali if x[1] != '-']
+                sh.query_start = qstart
+                sh.query_stop = qstop
+                sh.hit_start = hstart
+                sh.hit_stop = hstop
+                target_alignment = "".join(hsp.aln[0].upper())  # assume the first Sequence is always the target
+                sh.target_alignment = target_alignment
+                alignment = "".join(hsp.aln[1].upper())  # assume the first Sequence is always the target
+                sh.alignment = alignment
+                local, overall = simpleSeqID().getPercent(alignment, target_alignment, target_sequence)
+                sh.local_sequence_identity = np.round(local)
+                sh.overall_sequence_identity = np.round(overall)
+    
                 sh.score = hit.score
                 hit_name = hit.id + "_" + str(hsp.output_index)
                 sh.search_engine = "hhsearch"
-            sh.name = hit_name
-            hitDict[hit_name] = sh
+                sh.name = hit_name
+                if sh.rank <= max_hits:
+                    hitDict[hit_name] = sh
+
     return hitDict
 
 
-def _find_json_hits(json_file, target_sequence):
+def _find_json_hits(json_file, target_sequence, max_hits=10):
     hitDict = OrderedDict()
     with open(json_file, 'r') as f_in:
         data = json.load(f_in)
@@ -215,7 +268,8 @@ def _find_json_hits(json_file, target_sequence):
                 hit_name = hit['name'].split("_")[0] + "_" + str(hit['ndom'])
                 sh.name = hit_name
                 sh.search_engine = "phmmer"
-                hitDict[hit_name] = sh
+                if sh.rank <= max_hits:
+                    hitDict[hit_name] = sh
             except Exception:
                 logger.debug(f"Issue with target {hit['name']}")
     return hitDict

--- a/mrparse/mr_hit.py
+++ b/mrparse/mr_hit.py
@@ -100,12 +100,12 @@ class SequenceHit:
         return out_str
 
 
-def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=None, phmmer_dblvl=95, localrun=False, max_hits=10, nproc=1):
+def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=None, phmmer_dblvl=95, use_api=False, max_hits=10, nproc=1):
     target_sequence = seq_info.sequence
     af2 = False
     dbtype = None
     if search_engine == PHMMER:
-        if not localrun:
+        if use_api:
             if phmmer_dblvl == "af2":
                 logger.info("Attempting to run phmmer alphafold database search through EBI API..")
                 try:

--- a/mrparse/mr_hit.py
+++ b/mrparse/mr_hit.py
@@ -99,7 +99,7 @@ class SequenceHit:
         return out_str
 
 
-def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=None, phmmer_dblvl=95, localrun=False, max_hits=10):
+def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=None, phmmer_dblvl=95, localrun=False, max_hits=10, nproc=1):
     target_sequence = seq_info.sequence
     af2 = False
     dbtype = None
@@ -116,7 +116,7 @@ def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=Non
         else:
             if phmmer_dblvl == "af2":
                 af2 = True
-        logfile, dbtype = run_phmmer(seq_info, afdb_seqdb=afdb_seqdb, dblvl=phmmer_dblvl)
+        logfile, dbtype = run_phmmer(seq_info, afdb_seqdb=afdb_seqdb, dblvl=phmmer_dblvl, nproc=nproc)
         searchio_type = 'hmmer3-text'
     elif search_engine == HHSEARCH:
         searchio_type = 'hhsuite2-text'
@@ -298,7 +298,7 @@ def sort_hits_by_size(hits, ascending=False):
     return OrderedDict(sorted(hits.items(), key=lambda x: x[1].length, reverse=reverse))
 
 
-def run_phmmer(seq_info, afdb_seqdb=None, dblvl=95):
+def run_phmmer(seq_info, afdb_seqdb=None, dblvl=95, nproc=1):
     logfile = f"phmmer_{dblvl}.log"
     alnfile = f"phmmerAlignment_{dblvl}.log"
     phmmerTblout = f"phmmerTblout_{dblvl}.log"
@@ -325,6 +325,7 @@ def run_phmmer(seq_info, afdb_seqdb=None, dblvl=95):
            '--domtblout', phmmerDomTblout,
            '--F1', '1e-15',
            '--F2', '1e-15',
+           '--cpu', str(nproc),
            '-A', alnfile,
            str(seq_info.sequence_file), str(seqdb)]
     else:
@@ -332,6 +333,7 @@ def run_phmmer(seq_info, afdb_seqdb=None, dblvl=95):
            '--notextw',
            '--tblout', phmmerTblout,
            '--domtblout', phmmerDomTblout,
+           '--cpu', str(nproc),
            '-A', alnfile,
            str(seq_info.sequence_file), str(seqdb)]
     stdout = run_cmd(cmd)

--- a/mrparse/mr_homolog.py
+++ b/mrparse/mr_homolog.py
@@ -6,6 +6,9 @@ Created on 18 Oct 2018
 from collections import OrderedDict
 import copy
 import logging
+import os, sys
+import gzip
+import shutil
 from pathlib import Path
 from simbad.util.pdb_util import PdbStructure
 
@@ -124,7 +127,7 @@ class HomologData(object):
         return out_str
 
 
-def homologs_from_hits(hits, pdb_dir=None):
+def homologs_from_hits(hits, pdb_dir=None, pdb_local=None):
     if not HOMOLOGS_DIR.exists():
         HOMOLOGS_DIR.mkdir()
     homologs = OrderedDict()
@@ -134,31 +137,49 @@ def homologs_from_hits(hits, pdb_dir=None):
         hit._homolog = hlog
         hlog.pdb_url = PDB_BASE_URL + hit.pdb_id
         try:
-            hlog.pdb_file, hlog.molecular_weight, hlog.resolution = prepare_pdb(hit, pdb_dir)
+            hlog.pdb_file, hlog.molecular_weight, hlog.resolution = prepare_pdb(hit, pdb_dir, pdb_local)
         except PdbModelException as e:
             logger.critical(f"Error processing hit pdb {e}")
         homologs[hlog.name] = hlog
     return homologs
 
 
-def prepare_pdb(hit, pdb_dir):
+def prepare_pdb(hit, pdb_dir, pdb_local):
     """
-    Download pdb or take file from cache
-    trucate to required residues
+    Download pdb or take file from cache or local PDB mirror
+    truncate to required residues
     calculate the MW
 
     """
 
-    if pdb_dir != "None":
-        pdb_dir = Path(pdb_dir)
-        entry = list(pdb_dir.glob("*/*"))[0]
-        prefix, ext = entry.stem[:-4], entry.suffix
-        pdb_file = pdb_dir.joinpath(hit.pdb_id[1:3].lower(), f"{prefix}{hit.pdb_id.lower()}.{ext}")
+    print("Retrieving and preparing model: %s" % hit.name)
+  
+    localfile=False
+    if pdb_local is not None:
+        pdb_local_gzfile=os.path.join(pdb_local, hit.pdb_id[1:3], "pdb" + hit.pdb_id + ".ent.gz")
+        if not os.path.isfile(pdb_local_gzfile):
+            logger.info("pdb file not found in local mirror (%s)" % pdb_local_gzfile)
+            logger.info("attempting to download or take file from directory instead..")
+        else:
+            localfile=True
+            if not PDB_DIR.exists():
+                PDB_DIR.mkdir()
+            pdb_file = PDB_DIR.joinpath(f"{hit.pdb_id.lower()}.pdb")
+            with gzip.open(pdb_local_gzfile, 'rb') as f_in:
+                with open(pdb_file, 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
 
-    else:
-        if not PDB_DIR.exists():
-            PDB_DIR.mkdir()
-        pdb_file = PDB_DIR.joinpath(f"{hit.pdb_id.lower()}.pdb")
+    if not localfile:
+        if pdb_dir != "None":
+            pdb_dir = Path(pdb_dir)
+            entry = list(pdb_dir.glob("*/*"))[0]
+            prefix, ext = entry.stem[:-4], entry.suffix
+            pdb_file = pdb_dir.joinpath(hit.pdb_id[1:3].lower(), f"{prefix}{hit.pdb_id.lower()}.{ext}")
+    
+        else:
+            if not PDB_DIR.exists():
+                PDB_DIR.mkdir()
+            pdb_file = PDB_DIR.joinpath(f"{hit.pdb_id.lower()}.pdb")
 
     pdb_struct = PdbStructure()
     if pdb_file.exists():

--- a/mrparse/mr_search_model.py
+++ b/mrparse/mr_search_model.py
@@ -26,7 +26,7 @@ class SearchModelFinder(object):
         self.hhsearch_exe = kwargs.get("hhsearch_exe", None)
         self.hhsearch_db = kwargs.get("hhsearch_db", None)
         self.afdb_seqdb = kwargs.get("afdb_seqdb", None)
-        self.run_local = kwargs.get("run_local", False)
+        self.use_api = kwargs.get("use_api", False)
         self.max_hits = kwargs.get("max_hits", 10)
         self.nproc = kwargs.get("nproc", 1)
         self.hits = None
@@ -56,7 +56,7 @@ class SearchModelFinder(object):
         self.hits = mr_hit.find_hits(self.seq_info, search_engine=self.search_engine,
                                      hhsearch_exe=self.hhsearch_exe, hhsearch_db=self.hhsearch_db,
                                      afdb_seqdb=self.afdb_seqdb, phmmer_dblvl=self.phmmer_dblvl, 
-                                     localrun=self.run_local, max_hits=self.max_hits, nproc=self.nproc)
+                                     use_api=self.use_api, max_hits=self.max_hits, nproc=self.nproc)
         if not self.hits:
             logger.critical('SearchModelFinder PDB search could not find any hits!')
             return None
@@ -66,7 +66,7 @@ class SearchModelFinder(object):
     def find_model_regions(self):
         self.model_hits = mr_hit.find_hits(self.seq_info, search_engine="phmmer",
                                            hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=self.afdb_seqdb, phmmer_dblvl="af2", 
-                                           localrun=self.run_local, max_hits=self.max_hits, nproc=self.nproc)
+                                           use_api=self.use_api, max_hits=self.max_hits, nproc=self.nproc)
         if not self.model_hits:
             logger.critical('SearchModelFinder EBI Alphafold database search could not find any hits!')
             return None

--- a/mrparse/mr_search_model.py
+++ b/mrparse/mr_search_model.py
@@ -25,6 +25,8 @@ class SearchModelFinder(object):
         self.hhsearch_exe = kwargs.get("hhsearch_exe", None)
         self.hhsearch_db = kwargs.get("hhsearch_db", None)
         self.afdb_seqdb = kwargs.get("afdb_seqdb", None)
+        self.run_local = kwargs.get("run_local", False)
+        self.max_hits = kwargs.get("max_hits", 10)
         self.hits = None
         self.model_hits = None
         self.regions = None
@@ -51,7 +53,8 @@ class SearchModelFinder(object):
     def find_homolog_regions(self):
         self.hits = mr_hit.find_hits(self.seq_info, search_engine=self.search_engine,
                                      hhsearch_exe=self.hhsearch_exe, hhsearch_db=self.hhsearch_db,
-                                     afdb_seqdb=self.afdb_seqdb, phmmer_dblvl=self.phmmer_dblvl)
+                                     afdb_seqdb=self.afdb_seqdb, phmmer_dblvl=self.phmmer_dblvl, 
+                                     localrun=self.run_local, max_hits=self.max_hits)
         if not self.hits:
             logger.critical('SearchModelFinder PDB search could not find any hits!')
             return None
@@ -60,7 +63,8 @@ class SearchModelFinder(object):
 
     def find_model_regions(self):
         self.model_hits = mr_hit.find_hits(self.seq_info, search_engine="phmmer",
-                                           hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=self.afdb_seqdb, phmmer_dblvl="af2")
+                                           hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=self.afdb_seqdb, phmmer_dblvl="af2", 
+                                           localrun=self.run_local, max_hits=self.max_hits)
         if not self.model_hits:
             logger.critical('SearchModelFinder EBI Alphafold database search could not find any hits!')
             return None

--- a/mrparse/mr_search_model.py
+++ b/mrparse/mr_search_model.py
@@ -27,6 +27,7 @@ class SearchModelFinder(object):
         self.afdb_seqdb = kwargs.get("afdb_seqdb", None)
         self.run_local = kwargs.get("run_local", False)
         self.max_hits = kwargs.get("max_hits", 10)
+        self.nproc = kwargs.get("nproc", 1)
         self.hits = None
         self.model_hits = None
         self.regions = None
@@ -54,7 +55,7 @@ class SearchModelFinder(object):
         self.hits = mr_hit.find_hits(self.seq_info, search_engine=self.search_engine,
                                      hhsearch_exe=self.hhsearch_exe, hhsearch_db=self.hhsearch_db,
                                      afdb_seqdb=self.afdb_seqdb, phmmer_dblvl=self.phmmer_dblvl, 
-                                     localrun=self.run_local, max_hits=self.max_hits)
+                                     localrun=self.run_local, max_hits=self.max_hits, nproc=self.nproc)
         if not self.hits:
             logger.critical('SearchModelFinder PDB search could not find any hits!')
             return None
@@ -64,7 +65,7 @@ class SearchModelFinder(object):
     def find_model_regions(self):
         self.model_hits = mr_hit.find_hits(self.seq_info, search_engine="phmmer",
                                            hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=self.afdb_seqdb, phmmer_dblvl="af2", 
-                                           localrun=self.run_local, max_hits=self.max_hits)
+                                           localrun=self.run_local, max_hits=self.max_hits, nproc=self.nproc)
         if not self.model_hits:
             logger.critical('SearchModelFinder EBI Alphafold database search could not find any hits!')
             return None

--- a/mrparse/mr_search_model.py
+++ b/mrparse/mr_search_model.py
@@ -19,6 +19,7 @@ class SearchModelFinder(object):
         self.seq_info = seq_info
         self.hkl_info = kwargs.get("hkl_info", None)
         self.pdb_dir = kwargs.get("pdb_dir", None)
+        self.pdb_local = kwargs.get("pdb_local", None)
         self.search_engine = kwargs.get("search_engine", "phmmer")
         self.phmmer_dblvl = kwargs.get("phmmer_dblvl", 95)
         self.plddt_cutoff = kwargs.get("plddt_cutoff", 70)
@@ -75,7 +76,7 @@ class SearchModelFinder(object):
     def prepare_homologs(self):
         if not self.hits and self.regions:
             return None
-        self.homologs = mr_homolog.homologs_from_hits(self.hits, self.pdb_dir)
+        self.homologs = mr_homolog.homologs_from_hits(self.hits, self.pdb_dir, self.pdb_local)
         if self.hkl_info:
             mr_homolog.calculate_ellg(self.homologs, self.hkl_info)
         return self.homologs

--- a/mrparse/mr_version.py
+++ b/mrparse/mr_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 3, 4)
+__version_info__ = (0, 3, 5)
 __version__ = '.'.join(map(str, __version_info__))

--- a/mrparse/searchDB.py
+++ b/mrparse/searchDB.py
@@ -1,0 +1,433 @@
+#! /usr/bin/env ccp4-python
+#
+#     Copyright (C) 2022 Ronan Keegan
+#
+#     This code is distributed under the terms and conditions of the
+#     CCP4 Program Suite Licence Agreement as a CCP4 Application.
+#     A copy of the CCP4 licence can be obtained by writing to the
+#     CCP4 Secretary, Daresbury Laboratory, Warrington WA4 4AD, UK.
+#
+# A wrapper for phmmer
+#
+
+import os, sys
+import subprocess
+import shlex
+import time
+import pickle
+
+from mrbump.seq_align import simpleSeqID
+from mrbump.tools import MRBUMP_utils
+
+
+class PHHit:
+    def __init__(self):
+        self.chainName = ""
+        self.afdbName = ""
+        self.chainID = ""
+        self.domainID = ""
+        self.rank = ""
+        self.prob = 0.0
+        self.evalue = 0.0
+        self.pvalue = 0.0
+        self.score = 0.0
+        self.ndomains = 0
+        self.domScores = dict([])
+        self.alignment = ""
+        self.alnRange = ""
+        self.ecodRange = []
+        self.tarRange = [0,0]
+        self.tarExtent = 0
+        self.tarMidpoint = 0.0
+        self.cols = 0
+        self.localSEQID = 0.0
+        self.overallSEQID = 0.0
+        self.resolution = 0.0
+        self.expdta = None
+        self.releaseDate = None
+        self.alignments = dict([])
+        self.modelResRange = None
+        self.modelResStart = None
+        self.modelResEnd   = None
+
+    def __str__(self):
+        attrs = [k for k in self.__dict__.keys() if not k.startswith('_')]
+        INDENT = "  "
+        out_str = "Class: {}\nData:\n".format(self.__class__)
+        for a in sorted(attrs):
+            out_str += INDENT + "{} : {}\n".format(a, self.__dict__[a])
+        return out_str
+
+
+class Domains:
+    def __init__(self):
+        self.targetName = ""
+        self.ID = 0
+        self.midpoint = 0
+        self.extent = 0
+        self.matches = []
+        self.ranges = []
+
+    def __str__(self):
+        attrs = [k for k in self.__dict__.keys() if not k.startswith('_')]
+        INDENT = "  "
+        out_str = "Class: {}\nData:\n".format(self.__class__)
+        for a in sorted(attrs):
+            out_str += INDENT + "{} : {}\n".format(a, self.__dict__[a])
+        return out_str
+
+
+class Phmmer:
+    def __init__(self):
+        self.phmmerEXE = os.path.join(os.environ["CCP4"], "libexec", "phmmer")
+        self.cpu = 1
+        self.seqin = ""
+        self.seqdb = ""
+        self.seqout = ""
+        self.logfile = ""
+        self.alnfile = ""
+        self.iterations = 1
+        self.termination = False
+        self.workingDIR = ""
+
+        self.extentTolerance = 50
+        self.midpointTolerance = 20
+
+        self.resultsList = []
+        self.resultsDict = dict([])
+        self.targetDomainDict = dict([])
+
+    def getAlignments(self):
+        """ Get the alignments for each of the matches in the results list """
+
+        if os.path.isfile(self.alnfile) == False:
+            sys.stdout.write("Phmmer Error: can't find alignments file: \n  %s\n" % self.alnfile)
+            sys.exit()
+
+        f = open(self.alnfile, "r")
+        lines = f.readlines()
+        f.close()
+
+        for line in lines:
+            for i in self.resultsList:
+                if i[0:6] in line and "#=" not in line[0:2] and (line.split()[0].split("/")[-1] == self.resultsDict[i].alnRange):
+                    self.resultsDict[i].alignment += line.split()[-1]
+                    self.resultsDict[i].alnRange = line.split("/")[-1].split()[0]
+
+    def getPhmmerAlignments(self, targetSequence="", phmmerALNLog="", PDBLOCAL=None, DB=None, seqMetaDB=None):
+        """ Extract the alignments from the Phmmer logfile """
+
+        if os.path.isfile(self.logfile) == False:
+            sys.stdout.write("Phmmer Error: can't find log file: \n  %s\n" % self.logfile)
+            sys.exit()
+
+        # Collect other details from the run log
+        CAPTURE = False
+        count = 1
+        scoreList=[]
+        TEMPresultsDict = dict([])
+        for line in phmmerALNLog:
+
+            if "No hits satisfy inclusion thresholds; no alignment saved" in line:
+                sys.stdout.write("Sorry, Phmmer found no hits! Try HHpred. Exciting...\n")
+                return
+
+#     4.3e-36  125.7   6.1    4.6e-36  125.6   6.1    1.0  1  1smm_A    resolution: 1.36 experiment: XRAY release_date: 2004-03-16 [ 348741 : ALL ]
+            if CAPTURE:
+                hit = line.split()
+                if len(hit) >= 9: 
+                    if "-----" not in line.split()[0]:
+                        if "ECOD" not in DB:
+                            if "AFDB" in DB:
+                                hitName=hit[8].split(":")[1] + "_PHR"
+                            else:
+                                hitName=hit[8] + "_PHR"
+                            TEMPresultsDict[hitName] = PHHit()
+                            if hit[8].split(":")[0] == "AFDB":
+                                TEMPresultsDict[hitName].afdbName = hit[8].split(":")[1]
+                                TEMPresultsDict[hitName].chainID = "A"
+                                TEMPresultsDict[hitName].expdta = "AFDB"
+                                #TEMPresultsDict[hitName].resolution = float(hit[10])
+                                #TEMPresultsDict[hitName].releaseDate = hit[14]
+                            else:
+                                TEMPresultsDict[hitName].afdbName = hit[8][0:4]
+                                if len(hit[8]) >= 6:
+                                    TEMPresultsDict[hitName].chainID = hit[8][5:]
+                                else:
+                                    TEMPresultsDict[hitName].chainID = "A"
+                                tempRange=hit[20].replace("['", "").replace("']","").split("-")
+                                if len(tempRange) == 2:
+                                    TEMPresultsDict[hitName].modelResStart= int(tempRange[-2])
+                                    TEMPresultsDict[hitName].modelResEnd  = int(tempRange[-1])
+                                elif len(tempRange) == 3:
+                                    TEMPresultsDict[hitName].modelResStart= -(int(tempRange[-2]))
+                                    TEMPresultsDict[hitName].modelResEnd  = int(tempRange[-1])
+                                elif len(tempRange) == 4:
+                                    TEMPresultsDict[hitName].modelResStart= -(int(tempRange[-3]))
+                                    TEMPresultsDict[hitName].modelResEnd  = -(int(tempRange[-1]))
+                        else:
+                            hitName=hit[8].split("|")[1][1:5] + "_" + hit[8].split("|")[1][5:] + "_PHR"
+                            TEMPresultsDict[hitName] = PHHit()
+                            TEMPresultsDict[hitName].afdbName = hit[8].split("|")[1][1:5]
+                            TEMPresultsDict[hitName].chainID = hit[8][5:]
+                        TEMPresultsDict[hitName].rank = count
+                        TEMPresultsDict[hitName].chainName = hitName 
+                        TEMPresultsDict[hitName].score = float(hit[1])
+                        TEMPresultsDict[hitName].evalue = float(hit[3])
+                        TEMPresultsDict[hitName].ndomains = int(hit[7])
+                        #self.resultsDict[hit[1]].prob=float(out[35:40])
+                        #self.resultsDict[hit[1]].prob=float(hit[len(hit)-9])
+                        #self.resultsDict[hit[1]].score=float(hit[len(hit)-6])
+                        #self.resultsDict[hit[1]].evalue=float(hit[len(hit)-8])
+                        #self.resultsDict[hit[1]].pvalue=float(hit[len(hit)-7])
+                        #self.resultsDict[hit[1]].cols=float(hit[len(hit)-4])
+                        count = count + 1
+                else:
+                    CAPTURE = False
+
+            if "E-value" in line and "score" in line and "bias" in line and "Sequence" in line:
+                CAPTURE = True
+
+        # Open the Phmmer log file
+        if os.name == "nt":
+            plog = open(self.logfile, "r", newline="\r\n")
+        else:
+            plog = open(self.logfile, "r")
+        lines = plog.readlines()
+        plog.close()
+
+        import copy
+
+        # Loop over the lines in the log file to grab target-hit alignments
+        rawHitList=[]
+        count = 0
+        for line in lines:
+            if ">>" in line[:2]:
+                # Check the following line to make sure its not outside the threshold
+                if "No individual domains that satisfy reporting thresholds" not in lines[count+1]:
+                    if "ECOD" not in DB:
+                        if "AFDB" in DB:
+                            hit = line.split()[1].split(":")[1] + "_PHR"
+                        else:
+                            hit = line.split()[1] + "_PHR"
+                    else:
+                        hit = line.split()[1].split("|")[1][1:5] + "_" + line.split()[1].split("|")[1][5:] + "_PHR"
+                    # Count the number of domains
+                    domCount = 0
+                    domScores=dict([])
+                    domline = lines[count + 3]
+                    while domline.strip() != "":
+                        domCount = domCount + 1
+                        if hit in TEMPresultsDict:
+                            domainID=int(domline.split()[0])
+                            domScores[domainID]=float(domline.split()[2])
+                        domline = lines[count + 3 + domCount]
+    
+                    ecodRange=[]
+                    # Grab the alignment and the range it covers in the target sequence
+                    for s in range(domCount):
+                        if hit in TEMPresultsDict.keys():
+                            #hitname = "%s%d" % (hit, s + 1)
+                            rawHitList.append(hit)
+                            rawCount=rawHitList.count(hit)
+                            hitname = "%s_%d_%s" % (hit.split("_")[0], rawCount, hit.split("_")[1])
+                            self.resultsList.append(hitname)
+    
+                            self.resultsDict[hitname] = copy.deepcopy(TEMPresultsDict[hit])
+                            self.resultsDict[hitname].domainID = s + 1
+                            self.resultsDict[hitname].targetAlignment = (lines[count + 6 + domCount + (6 * s)]).split()[-2].upper()
+                            self.resultsDict[hitname].alignment = (lines[count + 8 + domCount + (6 * s)]).split()[-2].upper()
+                            self.resultsDict[hitname].score = domScores[self.resultsDict[hitname].domainID]
+                            # Get the ranges for the alignment
+                            start = (lines[count + 8 + domCount + (6 * s)]).split()[1].upper()
+                            end = (lines[count + 8 + domCount + (6 * s)]).split()[-1].upper()
+                            if self.resultsDict[hitname].modelResStart is not None:
+                                self.resultsDict[hitname].alnRange = "%d-%d" % (int(start)+self.resultsDict[hitname].modelResStart, int(end)+self.resultsDict[hitname].modelResStart)
+                            else:
+                                self.resultsDict[hitname].alnRange = "%s-%s" % (start, end)
+                            if "SW" in line.split()[1].split("-")[-1]:
+                                self.resultsDict[hitname].modelResRange="[" + line.split("[")[-1]
+                            else:
+                                self.resultsDict[hitname].modelResRange="['%s-%s']" % (start, end)
+                            # If we are using an ECOD database we need to capture all of the ranges presented
+                            if "ECOD" in DB:
+                                #print(lines[count + 8 + domCount + (6 * s)]).split("|")[-1].split()[0]
+                                ecodRange.append((lines[count + 8 + domCount + (6 * s)]).split("|")[-1].split()[0])
+                                #ecodRange=(lines[count + 8 + domCount + (6 * s)]).split("|")[-1].split()[0].split(":")[-1]
+                                #ecodRange=(lines[count + 8 + domCount + (6 * s)])[0].split("|").split()[-1].split(",")
+                                self.resultsDict[hitname].ecodRange=ecodRange
+                            startT = (lines[count + 6 + domCount + (6 * s)]).split()[1].upper()
+                            endT = (lines[count + 6 + domCount + (6 * s)]).split()[-1].upper()
+                            self.resultsDict[hitname].tarRange = [int(startT), int(endT)]
+                            self.resultsDict[hitname].tarExtent = (int(endT) - int(startT))
+                            self.resultsDict[hitname].tarMidpoint = ((float(endT) - float(startT)) / 2.0) + float(startT)
+    
+                            simpSID = simpleSeqID.simpleSeqID()
+                            local, overall = simpSID.getPercent(self.resultsDict[hitname].alignment,
+                                                                self.resultsDict[hitname].targetAlignment, targetSequence)
+    
+                            self.resultsDict[hitname].localSEQID = local
+                            self.resultsDict[hitname].overallSEQID = overall
+                            gr = MRBUMP_utils.getPDBres()
+                            if self.resultsDict[hitname].expdta != "AFDB":
+                                self.resultsDict[hitname].resolution, self.resultsDict[hitname].expdta, self.resultsDict[hitname].releaseDate \
+                                    =  gr.getResolution(pdbCODE=self.resultsDict[hitname].afdbName, PDBLOCAL=PDBLOCAL, seqMetaDB=seqMetaDB)
+                        
+            count = count + 1
+
+        # Figure out the domains for the target that have been matched
+        domCount = 1
+        self.targetDomainDict[domCount] = Domains()
+        self.targetDomainDict[domCount].ID = domCount
+        self.targetDomainDict[domCount].midpoint = self.resultsDict[self.resultsList[0]].tarMidpoint
+        self.targetDomainDict[domCount].extent = self.resultsDict[self.resultsList[0]].tarExtent
+        self.targetDomainDict[domCount].matches.append(self.resultsList[0])
+        self.targetDomainDict[domCount].ranges.append(self.resultsDict[self.resultsList[0]].tarRange)
+
+        for hitname in self.resultsList[1:]:
+            DOMFOUND = False
+            for count in self.targetDomainDict.keys():
+                # Has this domain been identified already?
+                if self.resultsDict[hitname].tarExtent >= self.targetDomainDict[count].extent - self.extentTolerance and self.resultsDict[hitname].tarExtent <= self.targetDomainDict[count].extent + self.extentTolerance and self.resultsDict[hitname].tarMidpoint >= self.targetDomainDict[count].midpoint - self.midpointTolerance and self.resultsDict[hitname].tarMidpoint <= self.targetDomainDict[count].midpoint + self.midpointTolerance:
+                    self.targetDomainDict[count].matches.append(hitname)
+                    self.targetDomainDict[count].ranges.append(self.resultsDict[hitname].tarRange)
+                    DOMFOUND = True
+                    break
+            # If we have a new domain set it up
+            if DOMFOUND == False:
+                domCount = domCount + 1
+                self.targetDomainDict[domCount] = Domains()
+                self.targetDomainDict[domCount].ID = domCount
+                self.targetDomainDict[domCount].midpoint = self.resultsDict[hitname].tarMidpoint
+                self.targetDomainDict[domCount].extent = self.resultsDict[hitname].tarExtent
+                self.targetDomainDict[domCount].matches.append(hitname)
+                self.targetDomainDict[domCount].ranges.append(self.resultsDict[hitname].tarRange)
+
+    def runPhmmer(self,
+                  seqin,
+                  seqdb,
+                  targetSequence,
+                  phmmerPickleFile=None,
+                  cpu=1,
+                  iterations=1,
+                  logfile="",
+                  alnfile="",
+                  debug=False,
+                  PDBLOCAL=None,
+                  DB=None,
+                  seqMetaDB=None,
+                  pgap=0.0):
+        """ Run Phmmer """
+
+        if logfile == "":
+            self.logfile = "phmmer.log"
+        else:
+            self.logfile = logfile
+
+        if alnfile == "":
+            self.alnfile = "phmmerAlignment.log"
+        else:
+            self.alnfile = alnfile
+
+        self.cpu = cpu
+        self.iterations = iterations
+        self.seqin = seqin
+        self.seqdb = seqdb
+
+        self.termination = False
+
+        # Test that pgap (--pextend) is set correctly
+        try:
+            pgap = float(pgap)
+            if pgap < 0.0 or pgap >= 1.0: 
+                sys.stdout.write("pgap (pextend for phmmer) set incorrectly, must be float (0<=x<1.0)")
+                sys.exit()
+        except ValueError:
+            sys.stdout.write("pgap (pextend for phmmer) set incorrectly, must be float (0<=x<1.0)")
+            sys.exit()
+
+        # Set the command line
+        if pgap != 0.0:
+            command_line = self.phmmerEXE + " --pextend %.2lf --cpu %d --notextw --F1 1e-15 --F2 1e-15 -A %s %s %s" % (
+                pgap, self.cpu, self.alnfile, self.seqin, self.seqdb)
+        else:
+            command_line = self.phmmerEXE + " --cpu %d --notextw --F1 1e-15 --F2 1e-15 -A %s %s %s" % (
+                self.cpu, self.alnfile, self.seqin, self.seqdb)
+        if debug == True:
+            sys.stdout.write("Phmmer command line:\n  %s\n" % command_line)
+            sys.stdout.write("\n")
+
+        # Launch program
+        if os.name == "nt":
+            process_args = shlex.split(command_line, posix=False)
+            p = subprocess.Popen(
+                process_args,
+                bufsize=0,
+                shell="False",
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT)
+        else:
+            process_args = shlex.split(command_line)
+            p = subprocess.Popen(process_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        (child_stdout, child_stdin) = (p.stdout, p.stdin)
+
+        # Write the input
+        child_stdin.close()
+
+        # Open the log file for writing
+        log = open(self.logfile, "w")
+        phmmerALNLog = []
+
+        # Watch the output for successful termination
+        out = child_stdout.readline().decode()
+
+        while out:
+            phmmerALNLog.append(out)
+            if debug == True:
+                sys.stdout.write(out)
+
+            if '[ok]' in out:
+                self.termination = True
+
+            if "E-value" in out and "score" in out and "bias" in out and "Sequence" in out:
+                out = child_stdout.readline().decode()
+
+            log.write(out)
+            log.flush()
+            out = child_stdout.readline().decode()
+
+        child_stdout.close()
+
+        # Get the alignemnts for each of the hits
+        self.getPhmmerAlignments(targetSequence, phmmerALNLog, PDBLOCAL=PDBLOCAL, DB=DB, seqMetaDB=seqMetaDB)
+
+        if phmmerPickleFile is not None:
+            pf=open(phmmerPickleFile, "wb")
+            pickle.dump(self.resultsDict,pf,pickle.HIGHEST_PROTOCOL)
+            pf.close()
+
+
+if __name__ == "__main__":
+
+    targetSequence = "MGSSHHHHHHSQDPNSSSMAERFDNLVEGLTEERAMAVILADPDSLERPVDKYMAATRLGASNSEESLDVLIQAAELDPEHLFNRITRRKAIDALGRRKSPKALPSLFKALKCSDEAAVINSVEAITKIDAPLTEADHEKLLEALKGEDIQKRAVIQAFCRLGVPGVINSISPLQDDSNPLVAGAARAYMSKVALQPDGLEVLIPQLVDPIAGRRRSAVIDLGDAGDVTRLEALVTAPVSMSLRARSAFQLVDPDKTCQVPEKYAELITQLLQDNPQQLKLRKEWICDIEPTEIENNLQHRDEARQYGGASSLMAMPKAERMILINEIKEKLWSDYVTHYYLTAVVGLQGLEERSDLIRLALAETIPQYTKSRIAAAWGCLRLGLVDQKPLLEELSVSAFWLPLKWTCQRVLKQLS"
+    seqin = os.path.join("example.fasta")
+    seqdb = os.path.join("mill.fasta")
+
+    # Read in the database
+    from mrbump.tools import MRBUMP_utils
+    gr = MRBUMP_utils.getPDBres()
+    seqMetaDB=gr.readPDBALL()
+
+    ph = Phmmer()
+    ph.runPhmmer(
+        seqin=seqin,
+        seqdb=seqdb,
+        targetSequence=targetSequence,
+        DB="AFDB",
+        seqMetaDB=seqMetaDB)
+
+    for x in ph.resultsDict.keys():
+        print(x)
+        print(ph.resultsDict[x])

--- a/mrparse/searchDB.py
+++ b/mrparse/searchDB.py
@@ -34,7 +34,8 @@ class PHHit:
         self.ndomains = 0
         self.domScores = dict([])
         self.alignment = ""
-        self.alnRange = ""
+        #self.alnRange = ""
+        self.alnRange = [0,0]
         self.ecodRange = []
         self.tarRange = [0,0]
         self.tarExtent = 0
@@ -250,9 +251,11 @@ class Phmmer:
                             start = (lines[count + 8 + domCount + (6 * s)]).split()[1].upper()
                             end = (lines[count + 8 + domCount + (6 * s)]).split()[-1].upper()
                             if self.resultsDict[hitname].modelResStart is not None:
-                                self.resultsDict[hitname].alnRange = "%d-%d" % (int(start)+self.resultsDict[hitname].modelResStart, int(end)+self.resultsDict[hitname].modelResStart)
+                                #self.resultsDict[hitname].alnRange = "%d-%d" % (int(start)+self.resultsDict[hitname].modelResStart, int(end)+self.resultsDict[hitname].modelResStart)
+                                self.resultsDict[hitname].alnRange = [int(start)+self.resultsDict[hitname].modelResStart, int(end)+self.resultsDict[hitname].modelResStart]
                             else:
-                                self.resultsDict[hitname].alnRange = "%s-%s" % (start, end)
+                                #self.resultsDict[hitname].alnRange = "%s-%s" % (start, end)
+                                self.resultsDict[hitname].alnRange = [int(start.replace("(","")), int(end.replace(")",""))]
                             if "SW" in line.split()[1].split("-")[-1]:
                                 self.resultsDict[hitname].modelResRange="[" + line.split("[")[-1]
                             else:

--- a/mrparse/searchDB.py
+++ b/mrparse/searchDB.py
@@ -140,15 +140,21 @@ class Phmmer:
                         if "ECOD" not in DB:
                             if "AFDB" in DB:
                                 hitName=hit[8].split(":")[1] + "_PHR"
+                            elif "AFCCP4" in DB:
+                                hitName=hit[8].split("_")[0].replace("-model","") + "_PHR"
                             else:
                                 hitName=hit[8] + "_PHR"
                             TEMPresultsDict[hitName] = PHHit()
-                            if hit[8].split(":")[0] == "AFDB":
+                            if "AFDB" in DB:
                                 TEMPresultsDict[hitName].afdbName = hit[8].split(":")[1]
                                 TEMPresultsDict[hitName].chainID = "A"
                                 TEMPresultsDict[hitName].expdta = "AFDB"
                                 #TEMPresultsDict[hitName].resolution = float(hit[10])
                                 #TEMPresultsDict[hitName].releaseDate = hit[14]
+                            elif "AFCCP4" in DB:
+                                TEMPresultsDict[hitName].afdbName = hit[8].split("_")[0].replace("-model","")
+                                TEMPresultsDict[hitName].chainID = "A"
+                                TEMPresultsDict[hitName].expdta = "AFDB"
                             else:
                                 TEMPresultsDict[hitName].afdbName = hit[8][0:4]
                                 if len(hit[8]) >= 6:
@@ -206,8 +212,11 @@ class Phmmer:
                 # Check the following line to make sure its not outside the threshold
                 if "No individual domains that satisfy reporting thresholds" not in lines[count+1]:
                     if "ECOD" not in DB:
+                        print(">>>>", line)
                         if "AFDB" in DB:
                             hit = line.split()[1].split(":")[1] + "_PHR"
+                        elif "AFCCP4" in DB:
+                            hit = line.split()[1].split("_")[0].replace("-model","") + "_PHR"
                         else:
                             hit = line.split()[1] + "_PHR"
                     else:

--- a/mrparse/searchDB.py
+++ b/mrparse/searchDB.py
@@ -212,7 +212,6 @@ class Phmmer:
                 # Check the following line to make sure its not outside the threshold
                 if "No individual domains that satisfy reporting thresholds" not in lines[count+1]:
                     if "ECOD" not in DB:
-                        print(">>>>", line)
                         if "AFDB" in DB:
                             hit = line.split()[1].split(":")[1] + "_PHR"
                         elif "AFCCP4" in DB:

--- a/mrparse/searchDB.py
+++ b/mrparse/searchDB.py
@@ -78,7 +78,7 @@ class Domains:
         return out_str
 
 
-class Phmmer:
+class phmmer:
     def __init__(self):
         self.phmmerEXE = os.path.join(os.environ["CCP4"], "libexec", "phmmer")
         self.cpu = 1
@@ -431,7 +431,7 @@ if __name__ == "__main__":
     gr = MRBUMP_utils.getPDBres()
     seqMetaDB=gr.readPDBALL()
 
-    ph = Phmmer()
+    ph = phmmer()
     ph.runPhmmer(
         seqin=seqin,
         seqdb=seqdb,

--- a/tests/data_constants.py
+++ b/tests/data_constants.py
@@ -1,7 +1,7 @@
 TWOUVO_SEQ = 'ERCGEQGSNMECPNNLCCSQYGYCGMGGDYCGKGCQNGACWTSKRCGSQAGGATCTNNQCCSQYGYCGFGAEYCGAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCGKDAGGRVCTNNYCCSKWGSCGIGPGYCGAGCQSGGCDG'
 FIVEHXG_SEQ = 'MRYFFMAEPIRAMEGDLLGVEIITHFASSPARPLHPEFVISSWDNSQKRRFLLDLLRTIAAKHGWFLRHGLFCIVNIDRGMAQLVLQDKDIRALLHAMLFVELQVAEHFSCQDNVLVDPLIHALHKQPNPLWLGDLGVGNATAAPLVCGCFSGVKLDRSFFVSQIEKMTFPLLVKHIRHYCDKIVVGGQENARYLPALKTAGIWATQGTLFPSVALEEIETLLLGSRMNTLRESNMGTMHTSELLKHIYDINLSYLLLAQRLIVQDKASAMFRLGINEEMANTLGALSLPQMVKLAETNQLVCHFRFDDHQTITRLTQDSRVDDLQQIHTGIMLSTRLLNEVDDTARKKRA'
 
-PHMMER_LOG_TXT = """# phmmer :: search a protein sequence against a protein database
+PHMMER_LOG_TXT_OLD = """# phmmer :: search a protein sequence against a protein database
 # HMMER 3.1b1 (May 2013); http://hmmer.org/
 # Copyright (C) 2013 Howard Hughes Medical Institute.
 # Freely distributed under the GNU General Public License (GPLv3).
@@ -464,3 +464,190 @@ PHMMER_AF_JSON = '{"results":{"hits":[{"archScore":"8","ph":"Streptophyta","arch
                  ':5893,"sys":0,"n_past_fwd":38,"total":4,"nmodels":1,"nincluded":"36","n_past_vit":541,"nreported":"' \
                  '36","domZ":36},"uuid":"B401DCCA-8999-11EC-BB2E-100EE976C163","_internal":{"lowevalue":"1.5e-07","hi' \
                  'ghevalue":"5.4e-74"}}}'
+
+
+PHMMER_LOG_TXT = """# phmmer :: search a protein sequence against a protein database
+# HMMER 3.3.2 (Nov 2020); http://hmmer.org/
+# Copyright (C) 2020 Howard Hughes Medical Institute.
+# Freely distributed under the BSD open source license.
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# query sequence file:             /home/rmk65/opt/repos/github/MrParse/data/2uvoA.fasta
+# target sequence database:        /tmp/rmk65/phmmer_r95_a100.fasta
+# MSA of hits saved to file:       phmmerAlignment_95.log
+# per-seq hits tabular output:     phmmerTblout_95.log
+# per-dom hits tabular output:     phmmerDomTblout_95.log
+# max ASCII text line length:      unlimited
+# number of worker threads:        1
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+Query:       2UVO:A|PDBID|CHAIN|SEQUENCE  [L=171]
+Scores for complete sequences (score includes all domains):
+   --- full sequence ---   --- best 1 domain ---    -#dom-
+    E-value  score  bias    E-value  score  bias    exp  N  Sequence Description
+    ------- ------ -----    ------- ------ -----   ---- --  -------- -----------
+     2e-109  366.5  96.9   2.2e-109  366.3  96.9    1.0  1  2uvo_F    resolution: 1.40 experiment: XRAY release_date: 2008-05-27 [ 196262 : ALL ] ['2-171'] <RLEVEL>95<RLEVEL>
+    5.8e-62  211.3  96.0      1e-61  210.5  96.0    1.4  1  6stq_B    resolution: 1.50 experiment: XRAY release_date: 2021-07-14 [ 228730 : ALL ] ['1-170'] <RLEVEL>95<RLEVEL>
+    2.6e-26   94.8  53.8    6.5e-26   93.5  53.8    1.5  1  1ulk_B    resolution: 1.80 experiment: XRAY release_date: 2003-12-23 [ 420299 : ALL ] ['201-326'] <RLEVEL>95<RLEVEL>
+    1.5e-18   69.4  33.2    1.6e-18   69.3  33.2    1.0  1  1uha_A    resolution: 1.50 experiment: XRAY release_date: 2004-04-13 [ 343113 : ALL ] ['1-82'] <RLEVEL>95<RLEVEL>
+    8.9e-12   47.3  10.8    8.9e-12   47.3  10.8    1.0  1  4wp4_A    resolution: 1.43 experiment: XRAY release_date: 2015-03-04 [ 395476 : ALL ] ['1-43'] <RLEVEL>95<RLEVEL>
+    1.7e-11   46.4  37.0    1.9e-11   46.2  37.0    1.1  1  1en2_A    resolution: 1.40 experiment: XRAY release_date: 2000-06-21 [ 386248 : ALL ] ['2-86'] <RLEVEL>95<RLEVEL>
+      7e-11   44.4  36.1    7.9e-11   44.2  36.1    1.1  1  1iqb_B    resolution: 1.90 experiment: XRAY release_date: 2001-11-07 [ 423878 : ALL ] ['2-89'] <RLEVEL>95<RLEVEL>
+    6.3e-09   38.0  16.0    6.6e-09   37.9  16.0    1.0  1  4mpi_B    resolution: 1.60 experiment: XRAY release_date: 2014-08-27 [ 443733 : ALL ] ['-1-43'] <RLEVEL>95<RLEVEL>
+    2.7e-08   35.9  19.7    2.7e-08   35.9  19.7    2.5  3  2dkv_A    resolution: 2.00 experiment: XRAY release_date: 2007-05-01 [ 405547 : ALL ] ['33-330'] <RLEVEL>95<RLEVEL>
+  ------ inclusion threshold ------
+      0.029   16.2  18.7      0.029   16.2  18.7    1.1  1  1p9g_A    resolution: 0.84 experiment: XRAY release_date: 2004-06-01 [ 432396 : ALL ] ['2-41'] <RLEVEL>95<RLEVEL>
+
+
+Domain annotation for each sequence (and alignments):
+>> 2uvo_F  resolution: 1.40 experiment: XRAY release_date: 2008-05-27 [ 196262 : ALL ] ['2-171'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !  366.3  96.9  3.7e-113  2.2e-109       2     171 .]       1     170 []       1     170 [] 1.00
+
+  Alignments for each domain:
+  == domain 1  score: 366.3 bits;  conditional E-value: 3.7e-113
+  2UVO:A|PDBID|CHAIN|SEQUENCE   2 rcgeqgsnmecpnnlccsqygycgmggdycgkgcqngacwtskrcgsqaggatctnnqccsqygycgfgaeycgagcqggpcradikcgsqaggklcpnnlccsqwgfcglgsefcgggcqsgacstdkpcgkdaggrvctnnyccskwgscgigpgycgagcqsggcdg 171
+                                  rcgeqgsnmecpnnlccsqygycgmggdycgkgcqngacwtskrcgsqaggatctnnqccsqygycgfgaeycgagcqggpcradikcgsqaggklcpnnlccsqwgfcglgsefcgggcqsgacstdkpcgkdaggrvctnnyccskwgscgigpgycgagcqsggcdg
+                       2uvo_F   1 RCGEQGSNMECPNNLCCSQYGYCGMGGDYCGKGCQNGACWTSKRCGSQAGGATCTNNQCCSQYGYCGFGAEYCGAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCGKDAGGRVCTNNYCCSKWGSCGIGPGYCGAGCQSGGCDG 170
+                                  8************************************************************************************************************************************************************************8 PP
+
+>> 6stq_B  resolution: 1.50 experiment: XRAY release_date: 2021-07-14 [ 228730 : ALL ] ['1-170'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !  210.5  96.0   1.7e-65     1e-61       2     169 ..       3     169 ..       2     170 .] 0.98
+
+  Alignments for each domain:
+  == domain 1  score: 210.5 bits;  conditional E-value: 1.7e-65
+  2UVO:A|PDBID|CHAIN|SEQUENCE   2 rcgeqgsnmecpnnlccsqygycgmggdycgkgcqngacwtskrcgsqaggatctnnqccsqygycgfgaeycgagcqggpcradikcgsqaggklcpnnlccsqwgfcglgsefcgggcqsgacstdkpcgkdaggrvctnnyccskwgscgigpgycgagcqsggc 169
+                                  +cg+qg    cpnn ccs+ygycg+g  ycg gcq+g c   krcg qa+g tc nn ccs+ gycgfg+eycgagcqggpcrad  cg     +lcp+nlccsqwgfcglg efcg gcqsgac +   cg+ a g  ctnnycc   g cg+g  ycgagcqsg c
+                       6stq_B   3 ECGKQGGGALCPNNKCCSRYGYCGFGPAYCGTGCQSGGCCPGKRCGDQANGETCPNNLCCSEDGYCGFGSEYCGAGCQGGPCRADKLCGXXXXXQLCPDNLCCSQWGFCGLGVEFCGDGCQSGACCS-MRCGRQADGAKCTNNYCCGASGYCGLGGDYCGAGCQSGPC 169
+                                  6****************************************************************************************************************************87.56************************************99 PP
+
+>> 1ulk_B  resolution: 1.80 experiment: XRAY release_date: 2003-12-23 [ 420299 : ALL ] ['201-326'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   93.5  53.8   1.1e-29   6.5e-26      46     166 ..       4     120 ..       1     124 [. 0.54
+
+  Alignments for each domain:
+  == domain 1  score: 93.5 bits;  conditional E-value: 1.1e-29
+  2UVO:A|PDBID|CHAIN|SEQUENCE  46 cgsqaggatctnnqccsqygycgfgaeycgagcqggpcradikcgsqaggklcpnnlccsqwgfcglgsefcgggcqsgacstdkpcgkdaggrvctnnyccskwgscgigpgycgagcqs 166
+                                  cg +a+g  c +  ccsq+gycg   eycg gcq+  c  + +cg + ggk c + lccsq+g+cg +   cg gcqs  cs    cgkd ggr+ct + ccs++g cg+   +c  gcqs
+                       1ulk_B   4 CGVRASGRVCPDGYCCSQWGYCGTTEEYCGKGCQS-QCDYN-RCGKEFGGKECHDELCCSQYGWCGNSDGHCGEGCQS-QCSYW-RCGKDFGGRLCTEDMCCSQYGWCGLTDDHCEDGCQS 120
+                                  55556666666666666666666666666666654.34432.566666666666666666666666555566666655.35443.366666666666666666666666666666666655 PP
+
+>> 1uha_A  resolution: 1.50 experiment: XRAY release_date: 2004-04-13 [ 343113 : ALL ] ['1-82'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   69.3  33.2   2.7e-22   1.6e-18      88     169 ..       3      81 ..       1      82 [] 0.88
+
+  Alignments for each domain:
+  == domain 1  score: 69.3 bits;  conditional E-value: 2.7e-22
+  2UVO:A|PDBID|CHAIN|SEQUENCE  88 kcgsqaggklcpnnlccsqwgfcglgsefcgggcqsgacstdkpcgkdaggrvctnnyccskwgscgigpgycgagcqsggc 169
+                                  +cg +a+gk cpn  ccsqwg+cg    +cg gcqs  c     cg+d ggr+c  + ccsk+g cg +  +c  gcqs  c
+                       1uha_A   3 ECGERASGKRCPNGKCCSQWGYCGTTDNYCGQGCQSQ-CDY-WRCGRDFGGRLCEEDMCCSKYGWCGYSDDHCEDGCQSQ-C 81 
+                                  6999999999999999999999999999999999985.765.46999999999999999999999999999999999984.5 PP
+
+>> 4wp4_A  resolution: 1.43 experiment: XRAY release_date: 2015-03-04 [ 395476 : ALL ] ['1-43'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   47.3  10.8   1.5e-15   8.9e-12      88     124 ..       2      40 ..       1      43 [] 0.87
+
+  Alignments for each domain:
+  == domain 1  score: 47.3 bits;  conditional E-value: 1.5e-15
+  2UVO:A|PDBID|CHAIN|SEQUENCE  88 kcgsqaggklcpnnlccsqwgfcglgsefcgg..gcqsg 124
+                                  +cg qaggklcpnnlccsqwg+cg   e+c+   +cqs+
+                       4wp4_A   2 QCGRQAGGKLCPNNLCCSQWGWCGSTDEYCSPdhNCQSN 40 
+                                  6*****************************852268875 PP
+
+>> 1en2_A  resolution: 1.40 experiment: XRAY release_date: 2000-06-21 [ 386248 : ALL ] ['2-86'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   46.2  37.0   3.1e-15   1.9e-11       2      79 ..       1      82 [.       1      85 [] 0.76
+
+  Alignments for each domain:
+  == domain 1  score: 46.2 bits;  conditional E-value: 3.1e-15
+  2UVO:A|PDBID|CHAIN|SEQUENCE  2 rcgeqgsnmecpnnlccsqygycgmggdycgkgcqngacwtsk....rcgsqaggatctnnqccsqygycgfgaeycgag.cq 79
+                                 rcg qg    cp   ccs +g+cg +  ycg+ c+n  cw+ +    rcg+  g+  c  ++ccs +g+cg g +yc+ g cq
+                       1en2_A  1 RCGSQGGGSTCPGLRCCSIWGWCGDSEPYCGRTCEN-KCWSGErsdhRCGAAVGNPPCGQDRCCSVHGWCGGGNDYCSGGnCQ 82
+                                 788888888888888888888888888888888887.5887542223688888888888888888888888888888554255 PP
+
+>> 1iqb_B  resolution: 1.90 experiment: XRAY release_date: 2001-11-07 [ 423878 : ALL ] ['2-89'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   44.2  36.1   1.3e-14   7.9e-11       2      79 ..       1      82 [.       1      88 [] 0.82
+
+  Alignments for each domain:
+  == domain 1  score: 44.2 bits;  conditional E-value: 1.3e-14
+  2UVO:A|PDBID|CHAIN|SEQUENCE  2 rcgeqgsnmecpnnlccsqygycgmggdycgkgcqngacwtsk....rcgsqaggatctnnqccsqygycgfgaeyc.gagcq 79
+                                 rcg qg    cp   ccs +g+cg +  ycg+ c+n  cw+ +    rcg+  g+  c  ++ccs +g+cg g +yc g+ cq
+                       1iqb_B  1 RCGSQGGGGTCPALWCCSIWGWCGDSEPYCGRTCEN-KCWSGErsdhRCGAAVGNPPCGQDRCCSVHGWCGGGNDYCsGSKCQ 82
+                                 899999999999999999999999999999999998.6997652223799999999999999999999999999999445566 PP
+
+>> 4mpi_B  resolution: 1.60 experiment: XRAY release_date: 2014-08-27 [ 443733 : ALL ] ['-1-43'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   37.9  16.0   1.1e-12   6.6e-09      88     124 ..       4      40 ..       1      44 [. 0.79
+
+  Alignments for each domain:
+  == domain 1  score: 37.9 bits;  conditional E-value: 1.1e-12
+  2UVO:A|PDBID|CHAIN|SEQUENCE  88 kcgsqaggklcpnnlccsqwgfcglgsefcgggcqsg 124
+                                  +cg qagg lcp  lccsq+g+c+   e+cg+gcqs 
+                       4mpi_B   4 QCGRQAGGALCPGGLCCSQYGWCANTPEYCGSGCQSQ 40 
+                                  6888888888888888888888888888888888874 PP
+
+>> 2dkv_A  resolution: 2.00 experiment: XRAY release_date: 2007-05-01 [ 405547 : ALL ] ['33-330'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   35.9  19.7   4.5e-12   2.7e-08      88     126 ..       2      39 ..       1      46 [. 0.92
+   2 ?   -3.0   0.3       3.6   2.2e+04      17      17 ..     152     152 ..     135     173 .. 0.47
+   3 ?   -1.8   1.8       1.5   9.2e+03      52      77 ..     256     281 ..     236     294 .. 0.66
+
+  Alignments for each domain:
+  == domain 1  score: 35.9 bits;  conditional E-value: 4.5e-12
+  2UVO:A|PDBID|CHAIN|SEQUENCE  88 kcgsqaggklcpnnlccsqwgfcglgsefcgggcqsgac 126
+                                  +cg+qagg  cpn lccs+wg+cg  s+fcg gcqs  c
+                       2dkv_A   2 QCGAQAGGARCPNCLCCSRWGWCGTTSDFCGDGCQSQ-C 39 
+                                  6**********************************95.4 PP
+
+  == domain 2  score: -3.0 bits;  conditional E-value: 3.6
+  2UVO:A|PDBID|CHAIN|SEQUENCE  17 c 17 
+                                  c
+                       2dkv_A 152 C 152
+                                  2 PP
+
+  == domain 3  score: -1.8 bits;  conditional E-value: 1.5
+  2UVO:A|PDBID|CHAIN|SEQUENCE  52 gatctnnqccsqygycgfgaeycgag 77 
+                                  g  c +       +  gf   ycga 
+                       2dkv_A 256 GLECGHGPDDRVANRIGFYQRYCGAF 281
+                                  44455444444455566777777763 PP
+
+>> 1p9g_A  resolution: 0.84 experiment: XRAY release_date: 2004-06-01 [ 432396 : ALL ] ['2-41'] <RLEVEL>95<RLEVEL>
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 ?   16.2  18.7   4.7e-06     0.029      53      84 ..       8      39 ..       1      40 [] 0.74
+
+  Alignments for each domain:
+  == domain 1  score: 16.2 bits;  conditional E-value: 4.7e-06
+  2UVO:A|PDBID|CHAIN|SEQUENCE 53 atctnnqccsqygycgfgaeycgagcqggpcr 84
+                                   c    ccs ygycg ga ycgag     cr
+                       1p9g_A  8 RPCNAGLCCSIYGYCGSGAAYCGAGNCRCQCR 39
+                                 46888999999999999999999985555555 PP
+
+
+
+Internal pipeline statistics summary:
+-------------------------------------
+Query model(s):                            1  (171 nodes)
+Target sequences:                      60247  (16131101 residues searched)
+Passed MSV filter:                      1923  (0.0319186); expected 1204.9 (0.02)
+Passed bias filter:                      726  (0.0120504); expected 1204.9 (0.02)
+Passed Vit filter:                        60  (0.0009959); expected 60.2 (0.001)
+Passed Fwd filter:                        10  (0.000165983); expected 0.6 (1e-05)
+Initial search space (Z):              60247  [actual number of targets]
+Domain search space  (domZ):              10  [number of targets reported over threshold]
+# CPU time: 0.19u 0.00s 00:00:00.19 Elapsed: 00:00:00.12
+# Mc/sec: 22343.36
+//
+# Alignment of 9 hits satisfying inclusion thresholds saved to: phmmerAlignment_95.log
+[ok]
+"""


### PR DESCRIPTION
Updated with new command line options and set to version 0.3.5. New options include:
"pdb_local" - set a local PDB mirror
"use_api" -  use EBI phmmer search API (False by default)
"max_hits" - maximum number of models to prepare from each search 
"afdb_seqdb" - set path to local afdb sequence listing file (e.g. full fasta list for afdb)
"nproc" - number of CPU cores to give to Phmmer