### PR TITLE
Add phmmer_exe argument

### DIFF
--- a/mrparse/__main__.py
+++ b/mrparse/__main__.py
@@ -35,6 +35,7 @@ def main():
                               use_api=args.use_api,
                               max_hits=args.max_hits,
                               database=args.database,
+                              phmmer_exe=args.phmmer_exe,
                               nproc=args.nproc)
     except KeyboardInterrupt:
         sys.stderr.write("Interrupted by keyboard!")

--- a/mrparse/mr_analyse.py
+++ b/mrparse/mr_analyse.py
@@ -50,6 +50,7 @@ def run(seqin, **kwargs):
     use_api = kwargs.get('use_api', None)
     max_hits = kwargs.get('max_hits', 10)
     database = kwargs.get('database', 'all')
+    phmmer_exe = kwargs.get('phmmer_exe', None)
     nproc = kwargs.get('nproc', 1)
 
     # Need to make a work directory first as all logs go into there
@@ -93,7 +94,7 @@ def run(seqin, **kwargs):
                                             plddt_cutoff=plddt_cutoff, search_engine=search_engine, hhsearch_exe=hhsearch_exe, 
                                             hhsearch_db=hhsearch_db, afdb_seqdb=afdb_seqdb, bfvd_seqdb=bfvd_seqdb, esm_seqdb=esm_seqdb, 
                                             pdb_seqdb=pdb_seqdb, max_hits=max_hits, database=database, nproc=nproc, pdb_local=pdb_local, 
-                                            ccp4cloud=ccp4cloud)
+                                            ccp4cloud=ccp4cloud, phmmer_exe=phmmer_exe)
 
     classifier = None
     if do_classify:

--- a/mrparse/mr_args.py
+++ b/mrparse/mr_args.py
@@ -52,6 +52,7 @@ def mrparse_argparse(parser):
     sg.add_argument('--max_hits', required=False, type=int, choices=range(1,101), metavar="[1-100]", default=10, help='Maximum number of models to download and prepare for each database search')
     sg.add_argument('--nproc', required=False, type=int, default=1, help='Number of cores to use in phmmer search')
     sg.add_argument('--database', help='Database to search', default='all', choices=['all', 'pdb', 'afdb', 'bfvd', 'esmfold'])
+    sg.add_argument('--phmmer_exe', help="Location of phmmer binary (defaults to ccp4 version)")
     sg.add_argument('-v', '--version', action='version', version='%(prog)s version: ' + __version__)
 
 

--- a/mrparse/mr_hit.py
+++ b/mrparse/mr_hit.py
@@ -108,7 +108,7 @@ class SequenceHit:
         return out_str
 
 
-def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=None, bfvd_seqdb=None, esm_seqdb=None, pdb_seqdb=None, phmmer_dblvl=95, max_hits=10, nproc=1, ccp4cloud=False):
+def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=None, afdb_seqdb=None, bfvd_seqdb=None, esm_seqdb=None, pdb_seqdb=None, phmmer_dblvl=95, max_hits=10, nproc=1, ccp4cloud=False, phmmer_exe=None):
     target_sequence = seq_info.sequence
     dbtype = None
     if search_engine == PHMMER:
@@ -141,7 +141,7 @@ def find_hits(seq_info, search_engine=PHMMER, hhsearch_exe=None, hhsearch_db=Non
             else:
                 logger.info("Using CCP4 pdb sequence file..")
                 seqdb=None
-        logfile, dbtype = run_phmmer(seq_info, seqdb=seqdb, dblvl=phmmer_dblvl, nproc=nproc)
+        logfile, dbtype = run_phmmer(seq_info, seqdb=seqdb, dblvl=phmmer_dblvl, nproc=nproc, phmmer_exe=phmmer_exe)
         searchio_type = 'hmmer3-text'
     elif search_engine == HHSEARCH:
         searchio_type = 'hhsuite2-text'
@@ -353,16 +353,20 @@ def sort_hits_by_size(hits, ascending=False):
     return OrderedDict(sorted(hits.items(), key=lambda x: x[1].length, reverse=reverse))
 
 
-def run_phmmer(seq_info, seqdb=None, dblvl=95, nproc=1):
+def run_phmmer(seq_info, seqdb=None, dblvl=95, nproc=1, phmmer_exe=None):
     logfile = f"phmmer_{dblvl}.log"
     alnfile = f"phmmerAlignment_{dblvl}.log"
     phmmerTblout = f"phmmerTblout_{dblvl}.log"
     phmmerDomTblout = f"phmmerDomTblout_{dblvl}.log"
-    phmmerEXE = Path(os.environ["CCP4"], "libexec", "phmmer")
+    if phmmer_exe is not None and dblvl == "af2":
+        phmmerEXE=phmmer_exe
+    else:
+        phmmerEXE = Path(os.environ["CCP4"], "libexec", "phmmer")
     delete_db = False
     dbtype = None
+    print(phmmer_exe, dblvl)
     if dblvl == "af2":
-        if seqdb is not None:
+        if seqdb is not None or phmmer_exe is not None:
             dbtype = "AFDB"
         else:
             seqdb = Path(os.environ["CCP4"], "share", "mrbump", "data", "afdb.fasta")

--- a/mrparse/mr_search_model.py
+++ b/mrparse/mr_search_model.py
@@ -36,6 +36,7 @@ class SearchModelFinder(object):
         self.max_hits = kwargs.get("max_hits", 10)
         self.database = kwargs.get("database", "all")
         self.nproc = kwargs.get("nproc", 1)
+        self.phmmer_exe = kwargs.get("phmmer_exe", None)
         self.ccp4cloud = kwargs.get("ccp4cloud", False)
         self.hits = None
         self.af_model_hits = None
@@ -83,7 +84,7 @@ class SearchModelFinder(object):
                                      hhsearch_db=self.hhsearch_db, afdb_seqdb=self.afdb_seqdb, bfvd_seqdb=self.bfvd_seqdb,
                                      esm_seqdb=self.esm_seqdb, pdb_seqdb=self.pdb_seqdb,
                                      phmmer_dblvl=self.phmmer_dblvl, max_hits=self.max_hits,
-                                     nproc=self.nproc, ccp4cloud=self.ccp4cloud)
+                                     nproc=self.nproc, ccp4cloud=self.ccp4cloud, phmmer_exe=self.phmmer_exe)
         if not self.hits:
             logger.critical('SearchModelFinder PDB search could not find any hits!')
             return None
@@ -95,7 +96,7 @@ class SearchModelFinder(object):
                                               hhsearch_db=None, afdb_seqdb=self.afdb_seqdb, bfvd_seqdb=self.bfvd_seqdb,
                                               esm_seqdb=self.esm_seqdb, pdb_seqdb=self.pdb_seqdb,
                                               phmmer_dblvl="af2", max_hits=self.max_hits,
-                                              nproc=self.nproc, ccp4cloud=self.ccp4cloud)
+                                              nproc=self.nproc, ccp4cloud=self.ccp4cloud, phmmer_exe=self.phmmer_exe)
         if not self.af_model_hits:
             logger.critical('SearchModelFinder EBI Alphafold database search could not find any hits!')
             return None
@@ -107,7 +108,7 @@ class SearchModelFinder(object):
                                               hhsearch_db=None, afdb_seqdb=self.afdb_seqdb, bfvd_seqdb=self.bfvd_seqdb,
                                               esm_seqdb=self.esm_seqdb, pdb_seqdb=self.pdb_seqdb,
                                               phmmer_dblvl="bfvd", max_hits=self.max_hits,
-                                              nproc=self.nproc, ccp4cloud=self.ccp4cloud)
+                                              nproc=self.nproc, ccp4cloud=self.ccp4cloud, phmmer_exe=self.phmmer_exe)
         if not self.bfvd_model_hits:
             logger.critical('SearchModelFinder Big Fantastic Virus Database search could not find any hits!')
             return None
@@ -119,7 +120,7 @@ class SearchModelFinder(object):
                                               hhsearch_db=None, afdb_seqdb=self.afdb_seqdb, bfvd_seqdb=self.bfvd_seqdb,
                                               esm_seqdb=self.esm_seqdb, pdb_seqdb=self.pdb_seqdb,
                                               phmmer_dblvl="esmfold", max_hits=self.max_hits,
-                                              nproc=self.nproc, ccp4cloud=self.ccp4cloud)
+                                              nproc=self.nproc, ccp4cloud=self.ccp4cloud, phmmer_exe=self.phmmer_exe)
         if not self.esm_model_hits:
             logger.critical('SearchModelFinder ESMfold Atlas database search could not find any hits!')
             return None

--- a/mrparse/scripts/phmmer_wrap.sh
+++ b/mrparse/scripts/phmmer_wrap.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+afdb_split_dir=<path to AFDB sequence split files>
+
+seqin="${@:(-2):1}"
+phmmer_args="${@:1:$#-1}"
+
+ccp4-python -m mrbump.seq_align.phmmer_par --seqin ${seqin} -n 16 -f ${afdb_split_dir} -p
+
+$CCP4/libexec/phmmer ${phmmer_args} afdb_sequences.fasta
+

--- a/mrparse/scripts/phmmer_wrap.sh
+++ b/mrparse/scripts/phmmer_wrap.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 afdb_split_dir=<path to AFDB sequence split files>
+# The AFDB sequence split files are the split version of the sequences.fasta file provided by the AFDB
 
 seqin="${@:(-2):1}"
 phmmer_args="${@:1:$#-1}"


### PR DESCRIPTION
This option allows for setting the phmmer executable to a bespoke script. Used when running phmmer in parallel across a large database like the AFDB on a cluster.